### PR TITLE
fix: add time-based sorting for wallpaper files

### DIFF
--- a/src/plugin-qt/wallpaperslideshow/background/backgrounds.cpp
+++ b/src/plugin-qt/wallpaperslideshow/background/backgrounds.cpp
@@ -89,6 +89,13 @@ QStringList Backgrounds::getSysBgFIles()
     return files;
 }
 
+void Backgrounds::sortByTime(QFileInfoList listFileInfo)
+{
+    std::sort(listFileInfo.begin(), listFileInfo.end(), [=](const QFileInfo &f1, const QFileInfo &f2) {
+        return f1.lastModified().toSecsSinceEpoch() < f2.lastModified().toSecsSinceEpoch();
+    });
+}
+
 QStringList Backgrounds::getCustomBgFiles()
 {
     struct passwd *user = getpwuid(getuid());


### PR DESCRIPTION
1. Added new sortByTime method to Backgrounds class
2. Implemented sorting using QFileInfo's lastModified timestamp
3. Uses std::sort with custom comparator for chronological ordering
4. This enables displaying wallpapers in order of modification time
5. Needed for better organization of custom wallpapers by recency

fix: 添加壁纸文件基于时间的排序功能

1. 在Backgrounds类中添加新的sortByTime方法
2. 使用QFileInfo的lastModified时间戳实现排序
3. 使用std::sort和自定义比较器进行时间顺序排列
4. 实现按修改时间顺序显示壁纸的功能
5. 需要此功能以便按时间顺序更好地组织自定义壁纸

pms: BUG-325395

## Summary by Sourcery

New Features:
- Introduce sortByTime method in Backgrounds to order wallpaper files by last modified timestamp using std::sort