### PR TITLE
feat: 移除ipwatchd插件

### DIFF
--- a/src/plugin-sdbus/CMakeLists.txt
+++ b/src/plugin-sdbus/CMakeLists.txt
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-option(ENABLE_PLUGIN_IPWATCHD "Build plugin-ipwatchd" ON)
+option(ENABLE_PLUGIN_IPWATCHD "Build plugin-ipwatchd" OFF)
 
 if (ENABLE_PLUGIN_IPWATCHD)
     add_subdirectory("plugin-ipwatchd")


### PR DESCRIPTION
由于ipwatchd会导致io占用高, 移除IPwatchd

Log: 移除ipwatchd插件
PMS: BUG—339237
Influence: ip冲突检测

## Summary by Sourcery

Build:
- Turn off the ENABLE_PLUGIN_IPWATCHD CMake option so the ipwatchd plugin is no longer built.