### PR TITLE
chore: bump version to 1.0.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-services (1.0.19) unstable; urgency=medium
+
+  * feat: 移除ipwatchd插件
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 14 Jan 2026 14:49:28 +0800
+
 dde-services (1.0.18) unstable; urgency=medium
 
   * fix: correct default scale factor initialization


### PR DESCRIPTION
update changelog to 1.0.19

## Summary by Sourcery

Chores:
- Refresh Debian changelog entries to reflect release 1.0.19.