### PR TITLE
chore: disable direct D-Bus service execution

### DIFF
--- a/src/plugin-qt/xsettings/misc/dbus/org.deepin.dde.XSettings1.service
+++ b/src/plugin-qt/xsettings/misc/dbus/org.deepin.dde.XSettings1.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.dde.XSettings1
-Exec=/usr/bin/deepin-service-manager -n org.deepin.dde.XSettings1
+Exec=/usr/bin/false
 SystemdService=org.deepin.dde.XSettings1.service


### PR DESCRIPTION
Changed the D-Bus service file to disable direct execution via deepin- service-manager.
The Exec line now points to /usr/bin/false, ensuring the service can only be started via its systemd unit.
This change centralizes service management through systemd, improving consistency and control over the service lifecycle.

Influence:
1. Verify the org.deepin.dde.XSettings1 D-Bus service is not directly executable
2. Confirm the service starts correctly via its systemd service unit (org.deepin.dde.XSettings1.service)
3. Ensure D-Bus activation still works through systemd integration
4. Test that applications relying on this D-Bus interface continue to function normally

chore: 禁用直接 D-Bus 服务执行

修改了 D-Bus 服务文件，禁止通过 deepin-service-manager 直接执行。
现在 Exec 行指向 /usr/bin/false，确保该服务只能通过其 systemd 单元启动。 此更改通过 systemd 集中管理服务，提高了服务生命周期管理的一致性和控
制力。

Influence:
1. 验证 org.deepin.dde.XSettings1 D-Bus 服务无法直接执行
2. 确认服务能通过其 systemd 服务单元 (org.deepin.dde.XSettings1.service) 正确启动
3. 确保通过 systemd 集成的 D-Bus 激活仍然有效
4. 测试依赖此 D-Bus 接口的应用程序是否继续正常运行

## Summary by Sourcery

Enhancements:
- Disable direct execution of the org.deepin.dde.XSettings1 D-Bus service so it can only be started via its systemd service unit.