### PR TITLE
fix: apply scale factor to GTK cursor theme size

### DIFF
--- a/src/plugin-qt/xsettings/impl/xsettingsmanager.cpp
+++ b/src/plugin-qt/xsettings/impl/xsettingsmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "xsettingsmanager.h"
@@ -218,7 +218,13 @@ void XSettingsManager::handleDConfigChangedCb(const QString &key)
         updateXResources();
     } else if (key == "gtk-cursor-theme-size-base") {
         int cursorSizeBase = m_settingDconfig->value(key).toInt();
-        m_settingDconfig->setValue("gtk-cursor-theme-size", cursorSizeBase);
+        double scale = m_settingDconfig->value(dcKeyScaleFactor).toDouble();
+        if (scale <= 0) {
+            qWarning() << "invalid scale factor:" << scale << ", fallback to 1.0";
+            scale = 1.0;
+        }
+        qDebug() << "update gtk-cursor-theme-size to" << cursorSizeBase * scale;
+        m_settingDconfig->setValue("gtk-cursor-theme-size", cursorSizeBase * scale);
         return;
     }
 


### PR DESCRIPTION
When the DConfig key "gtk-cursor-theme-size-base" changes, the derived "gtk-cursor-theme-size" value is now calculated by multiplying the base size with the current scale factor. Previously, the base size was used directly without scaling, which could lead to incorrect cursor sizes on high-DPI displays. The change includes validation for the scale factor, defaulting to 1.0 if an invalid value is read, and logs a warning in both error and update cases for debugging purposes.

fix: 应用缩放因子到GTK光标主题大小

当DConfig键"gtk-cursor-theme-size-base"发生变化时，现在通过将基础大小乘 以当前缩放因子来计算派生的"gtk-cursor-theme-size"值。之前，基础大小被直
接使用而没有进行缩放，这可能导致在高DPI显示器上光标大小不正确。此更改包
括对缩放因子的验证，如果读取到无效值则回退到1.0，并在错误和更新情况下记
录警告信息以便调试。

pms: BUG-343215

## Summary by Sourcery

Bug Fixes:
- Correct the derived GTK cursor theme size on high-DPI displays by factoring in the current scale factor instead of using the unscaled base size.