### PR TITLE
xsettings: start after treeland-sd.service to avoid crash on Wayland

### DIFF
--- a/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
+++ b/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
@@ -6,6 +6,7 @@ CollectMode=inactive-or-failed
 
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target
+After=treeland-sd.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
The XSettings service uses QGuiApplication with the xcb platform plugin, which requires an X11 connection (via XWayland). On treeland/Wayland sessions, XWayland may not be ready yet when this service starts as part of dde-session-pre.target, causing a crash loop.

Add After=treeland-sd.service to ensure the service only starts after treeland (which launches XWayland) is ready. This ordering is safely ignored on pure X11 sessions where treeland-sd.service doesn't exist.

## Summary by Sourcery

Add a startup ordering dependency so the XSettings service waits for the treeland compositor on Wayland sessions to prevent crashes.

Bug Fixes:
- Ensure the XSettings service starts only after treeland-sd.service so it does not crash when XWayland is not yet available on Wayland sessions.

Deployment:
- Update the XSettings systemd service unit to start After=treeland-sd.service while remaining a no-op on pure X11 sessions.