### PR TITLE
chore: add Breaks and Replaces for dde-daemon

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,4 +24,6 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  deepin-service-manager (>= 1.0.5)
+Breaks: dde-daemon (<< 6.1.87)
+Replaces: dde-daemon (<< 6.1.87)
 Description: deepin desktop-environment plugins service


### PR DESCRIPTION
- Moved wallpaper blur functionality to dde-services.
- Added Breaks and Replaces for dde-daemon (<< 6.1.87) to handle file conflict during upgrade.
- This ensures smooth transition of files from dde-daemon to dde-services.

- 将壁纸模糊相关功能迁移至 dde-services。
- 为 dde-daemon (<< 6.1.87) 添加了 Breaks 和 Replaces，以解决升级过程中的文件冲突。
- 确保文件从 dde-daemon 到 dde-services 的平滑迁移。

Log: chore: add Breaks and Replaces for dde-daemon
Change-Id: Ia5e10f5d0e72259c310f70a3f0eb2e15f659331e

## Summary by Sourcery

Build:
- Update debian/control to declare appropriate Breaks and Replaces on dde-daemon (<< 6.1.87) for files moved to dde-services.