### PR TITLE
chore: update changelog to 1.0.24

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-services (1.0.24) unstable; urgency=medium
+
+  * fix(wallpapercache): use QImageReader scaled decoding to avoid OOM
+    on large images
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 May 2026 15:03:28 +0800
+
 dde-services (1.0.23) unstable; urgency=medium
 
   * chore: add Breaks and Replaces for dde-daemon


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.24

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.24
- 目标分支: master
