### PR TITLE
perf: remove Before ordering constraint on dde-session-daemon from XS…

### DIFF
--- a/src/plugin-qt/xsettings/impl/xsettingsmanager.cpp
+++ b/src/plugin-qt/xsettings/impl/xsettingsmanager.cpp
@@ -30,8 +30,18 @@ XSettingsManager::XSettingsManager(QObject *parent)
     , m_xcbUtils(XcbUtils::getInstance())
 {
     connect(m_settingDconfig, &DTK_CORE_NAMESPACE::DConfig::valueChanged, this, &XSettingsManager::handleDConfigChangedCb);
-    setScreenScaleFactors(getScreenScaleFactors(), false);
-    adjustScaleFactor(getRecommendedScaleFactor());
+
+    double scale = 0;
+    if (m_settingDconfig->isValid()) {
+        scale = m_settingDconfig->value("scale-factor").toDouble();
+    }
+
+    // scale <= 0 is invalid, use recommended scale factor
+    if (scale <= 0) {
+        setScreenScaleFactors(getScreenScaleFactors(), false);
+        adjustScaleFactor(getRecommendedScaleFactor());
+    }
+
     setSettings(getSettingsInSchema());
 
     updateDPI();

--- a/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
+++ b/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
@@ -7,8 +7,6 @@ CollectMode=inactive-or-failed
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target
 
-Before=org.dde.session.Daemon1.service
-
 [Service]
 Type=dbus
 BusName=org.deepin.dde.XSettings1


### PR DESCRIPTION
…ettings1 service

Remove the Before=org.dde.session.Daemon1.service ordering constraint from the XSettings1 D-Bus service unit. This allows dde-session-daemon to start in parallel with XSettings1, reducing startup serialization on the critical path.

移除 XSettings1 D-Bus 服务单元中对 dde-session-daemon 的 Before 排序约束， 使得 dde-session-daemon 可以与 XSettings1 并行启动，减少关键路径上的串行化等待。

Log: perf: remove Before ordering constraint on dde-session-daemon from XSettings1 service
Change-Id: I4fec93594441957f8ef21f5bcd1b43f0c228568c

## Summary by Sourcery

Enhancements:
- Remove the Before= dependency on dde-session-daemon from the XSettings1 D-Bus service to reduce unnecessary startup serialization.