### PR TITLE
chore: update changelog to 1.0.25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-services (1.0.25) unstable; urgency=medium
+
+  * perf: optimize XSettings1 startup — remove Before constraint, skip
+    redundant init, clean up debug code
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 15 May 2026 09:35:57 +0800
+
 dde-services (1.0.24) unstable; urgency=medium
 
   * fix(wallpapercache): use QImageReader scaled decoding to avoid OOM


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.25

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.25
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 1.0.25 in debian/changelog.