### PR TITLE
[暂不合并]chore(xsettings): add ExecStartPre to disable THP before service startup

### DIFF
--- a/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
+++ b/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
@@ -11,6 +11,7 @@ After=treeland-sd.service
 [Service]
 Type=dbus
 BusName=org.deepin.dde.XSettings1
+ExecStartPre=-/usr/libexec/dde-thp-disable
 ExecStart=/usr/bin/deepin-service-manager -n org.deepin.dde.XSettings1
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
1. Added ExecStartPre=-/usr/libexec/dde-thp-disable to XSettings1 D-Bus service
2. Ensures touchpad palm rejection (THP) is disabled before the XSettings service starts

Log: Run dde-thp-disable as ExecStartPre in XSettings1 D-Bus service

chore(xsettings): 在 XSettings 服务启动前添加 ExecStartPre 禁用 THP

1. 在 XSettings1 D-Bus service 中添加了 ExecStartPre=-/usr/libexec/dde-thp-disable
2. 确保在 XSettings 服务启动前禁用触摸板手掌防误触（THP）

Log: 在 XSettings1 D-Bus 服务中添加 dde-thp-disable 作为 ExecStartPre
PMS: TASK-390043

## Summary by Sourcery

Enhancements:
- Add a pre-start command to the XSettings1 D-Bus service to run dde-thp-disable before service startup.