### PR TITLE
fix(wallpaperslideshow): skip DBus registration on Wayland, handled b…

### DIFF
--- a/src/plugin-qt/wallpaperslideshow/plugin.cpp
+++ b/src/plugin-qt/wallpaperslideshow/plugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -17,6 +17,9 @@ extern "C" int DSMRegister(const char *name, void *data)
 {
     Q_UNUSED(name)
     Q_UNUSED(data)
+
+    if (qEnvironmentVariable("XDG_SESSION_TYPE") == QLatin1String("wayland"))
+        return 0;
 
     service = new WallpaperSlideshow();
     new WallpaperSlideshowAdaptor(service);


### PR DESCRIPTION
…y Treeland

1. Check XDG_SESSION_TYPE in DSMRegister and return early under Wayland
2. Treeland compositor manages wallpaper slideshow on Wayland sessions
3. Align with the same Wayland-guard pattern used in xsettings module

Log: Skip wallpaper slideshow DBus registration on Wayland, where Treeland handles it

fix(wallpaperslideshow): Wayland 下跳过壁纸轮播 DBus 注册，由 Treeland 处理

1. 在 DSMRegister 中检查 XDG_SESSION_TYPE，Wayland 下提前返回
2. Wayland 会话中壁纸轮播由 Treeland 合成器负责
3. 与 xsettings 模块中已有的 Wayland 守卫模式保持一致

Log: Wayland 下壁纸轮播由 Treeland 负责，跳过 DBus 注册