### PR TITLE
chore(transifex): add configuration for power plugin translations

### DIFF
--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -1,0 +1,8 @@
+filters:
+  - filter_type: file
+    source_file: src/plugin-qt/power/session/translations/plugin-power-session_en.ts
+    file_format: QT
+    source_language: en_US
+    translation_files_expression: src/plugin-qt/power/session/translations/plugin-power-session_<lang>.ts
+settings:
+    pr_branch_name: transifex_update_<br_unique_id>


### PR DESCRIPTION
1. Add Transifex config mapping source translation to language files
2. Set source language to en_US for plugin-power-session

Log: add transifex.yaml config for power plugin translations

chore(transifex): 为 power 插件添加 Transifex 翻译配置

1. 添加 Transifex 配置，映射源翻译文件到各语言文件
2. 设置源语言为 en_US 的 plugin-power-session

Log: 为 power 插件添加 transifex.yaml 翻译配置

## Summary by Sourcery

Build:
- Add Transifex YAML config to map QT power session plugin source translations to per-language files and set the source language to en_US.