### PR TITLE
chore: update changelog to 1.0.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-services (1.0.27) unstable; urgency=medium
+
+  * refactor(shortcut): use backslash line continuation in INI SubPaths
+  * feat(shortcut): add SwapHotkeys and ReplaceHotkey D-Bus methods
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 21:17:50 +0800
+
 dde-services (1.0.26) unstable; urgency=medium
 
   * chore(shortcut): remove taskswitch-enter shortcut config


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.27

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.27
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document the 1.0.27 release in debian/changelog.