### PR TITLE
chore: break and replace dde-daemon old version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,8 +37,8 @@ Depends:
  ${misc:Depends},
  deepin-service-manager (>> 1.0.21),
  dbus
-Breaks: dde-daemon (<< 6.1.87)
-Replaces: dde-daemon (<< 6.1.87)
+Breaks: dde-daemon (<< 6.1.94)
+Replaces: dde-daemon (<< 6.1.94)
 Description: deepin desktop-environment plugins service
  This package provides various system service plugins for Deepin Desktop
  Environment, including:


### PR DESCRIPTION
break and replace dde-daemon old version

Log: as title
Change-Id: Ia5b575b7da66534a5dd5d995943fbce560d3aa70

## Summary by Sourcery

Enhancements:
- Adjust Debian control rules to declare a break/replace relationship with legacy dde-daemon packages.