### PR TITLE
chore: update changelog to 1.0.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-services (1.0.28) unstable; urgency=medium
+
+  * chore: break and replace dde-daemon old version
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 05 Jun 2026 11:16:51 +0800
+
 dde-services (1.0.27) unstable; urgency=medium
 
   * refactor(shortcut): use backslash line continuation in INI SubPaths


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.28

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.28
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 1.0.28 in debian/changelog.