### PR TITLE
feat(shortcut): support multi-field searching for shortcuts

### DIFF
--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -162,10 +162,37 @@ ShortcutInfo KeybindingManager::LookupConflictShortcut(const QString &hotkey)
 QList<ShortcutInfo> KeybindingManager::SearchShortcuts(const QString &keyword)
 {
     QList<ShortcutInfo> list;
-    QList<KeyConfig> configs = m_keyConfigsMap.values();
-    for (const KeyConfig &config : configs) {
-        if (config.hotkeys.contains(keyword, Qt::CaseInsensitive)) {
+    if (keyword.isEmpty()) return list;
+
+    for (auto it = m_keyConfigsMap.constBegin(); it != m_keyConfigsMap.constEnd(); ++it) {
+        const KeyConfig &config = it.value();
+        if (!config.isValid()) continue;
+
+        // Match against shortcutId
+        if (config.getId().contains(keyword, Qt::CaseInsensitive)) {
             list.append(toShortcutInfo(config));
+            continue;
+        }
+
+        // Match against display name
+        if (config.displayName.contains(keyword, Qt::CaseInsensitive)) {
+            list.append(toShortcutInfo(config));
+            continue;
+        }
+
+        // Match against localized display name
+        QString localName = m_translationManager->translate(config.appId, config.displayName);
+        if (localName.contains(keyword, Qt::CaseInsensitive)) {
+            list.append(toShortcutInfo(config));
+            continue;
+        }
+
+        // Match against hotkey combinations
+        for (const QString &hk : config.hotkeys) {
+            if (hk.contains(keyword, Qt::CaseInsensitive)) {
+                list.append(toShortcutInfo(config));
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
- Support searching shortcuts by ID, localized name, English name, and hotkeys simultaneously.
- Update SearchShortcuts to use Qt::CaseInsensitive for performance.
- Avoid early return to ensure all matches are found.

- 支持通过 ID、本地化名称、英文名称和快捷键同时搜索快捷键。
- 更新 SearchShortcuts 使用 Qt::CaseInsensitive 以提高性能。
- 避免提前返回，以确保找到所有匹配项。

Log: feat(shortcut): support multi-field searching for shortcuts
Change-Id: Ie697d66101f0b95b28e033139a1aa92b5cb0ec9d

## Summary by Sourcery

Extend shortcut search capabilities and document control center integration with the new shortcut service.

New Features:
- Allow searching shortcuts simultaneously by ID, English name, localized name, and hotkey combinations.

Enhancements:
- Improve shortcut search robustness by ignoring invalid configs and handling empty keywords early.
- Add detailed documentation describing how dde-control-center integrates with the new shortcut and gesture services.