### PR TITLE
fix(wallpapercache): restrict bus name ownership

### DIFF
--- a/src/plugin-qt/wallpapercache/misc/org.deepin.dde.WallpaperCache.conf
+++ b/src/plugin-qt/wallpapercache/misc/org.deepin.dde.WallpaperCache.conf
@@ -15,7 +15,6 @@
 
   <!-- Allow anyone to invoke methods on the interfaces -->
   <policy context="default">
-    <allow own="org.deepin.dde.WallpaperCache"/>
     <allow send_destination="org.deepin.dde.WallpaperCache"/>
 
     <allow send_destination="org.deepin.dde.WallpaperCache"


### PR DESCRIPTION
## Summary
- Remove default ownership permission for org.deepin.dde.WallpaperCache on the system bus
- Keep method call permissions unchanged for existing callers
- Limit service name ownership to root and deepin-daemon

## Test
- xmllint --noout src/plugin-qt/wallpapercache/misc/org.deepin.dde.WallpaperCache.conf
- git diff --check -- src/plugin-qt/wallpapercache/misc/org.deepin.dde.WallpaperCache.conf

PMS: BUG-365669

## Summary by Sourcery

Enhancements:
- Remove default permission for arbitrary clients to own the org.deepin.dde.WallpaperCache D-Bus name on the system bus, limiting service name ownership to privileged components.