### PR TITLE
chore: update changelog to 1.0.29

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-services (1.0.29) unstable; urgency=medium
+
+  * fix(wallpapercache): restrict bus name ownership
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:45:36 +0800
+
 dde-services (1.0.28) unstable; urgency=medium
 
   * chore: break and replace dde-daemon old version


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.29

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.29
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog version metadata to 1.0.29 for the master branch.