### PR TITLE
fix(shortcut): skip ddm default session when counting display sessions

### DIFF
--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/powercontroller.cpp
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/powercontroller.cpp
@@ -237,7 +237,25 @@ bool PowerController::hasMultipleDisplaySession()
     QVariant v = displayMgr.property("Sessions");
     if (!v.isValid())
         return false;
-    return qdbus_cast<QList<QDBusObjectPath>>(v).size() >= 2;
+
+    const QList<QDBusObjectPath> sessions = qdbus_cast<QList<QDBusObjectPath>>(v);
+    if (!isWaylandSession())
+        return sessions.size() >= 2;
+
+    // On Treeland the default display manager (ddm) keeps a default session(dde)
+    int userSessions = 0;
+    for (const QDBusObjectPath &path : sessions) {
+        QDBusInterface session("org.freedesktop.DisplayManager", path.path(),
+                               "org.freedesktop.DisplayManager.Session",
+                               QDBusConnection::systemBus());
+        if (!session.isValid())
+            continue;
+        if (session.property("UserName").toString() == QLatin1String("dde"))
+            continue;
+        ++userSessions;
+    }
+
+    return userSessions >= 2;
 }
 
 void PowerController::doPrepareSuspend()


### PR DESCRIPTION
## Summary
- `hasMultipleDisplaySession()` counted `org.freedesktop.DisplayManager` `Sessions` and treated `>= 2` as multiple users logged in.
- On Wayland the default display manager (ddm) keeps a dde session alive alongside the user session, so a single login already exposes two sessions — the greeter session's `UserName` is `dde`. This misjudged a single user as multiple sessions and wrongly gated shutdown/suspend confirmation.
- Fix: query each session's `UserName` and skip the `dde` greeter before counting. On X11 there is no such `dde` session, so the filter is a no-op there.

## Verification
On a Treeland/ddm machine with a single user logged in, `org.freedesktop.DisplayManager.Sessions` returns two paths:
- `/org/freedesktop/DisplayManager/Session`  → UserName `dde`  (default)
- `/org/freedesktop/DisplayManager/Session0` → UserName `uos`  (real user)

After the fix, only the real session is counted, so a single user no longer trips the `>= 2` check; a second real login still does.

## Summary by Sourcery

Bug Fixes:
- Prevent shutdown/suspend confirmation from being incorrectly gated when only a single user is logged in but a ddm greeter session is also present.