### PR TITLE
feat(shortcut): add dynamic category metadata

### DIFF
--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3down/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3down/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3left/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3left/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3right/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3right/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3up/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3up/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4down/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4down/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4left/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4left/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4right/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4right/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4up/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4up/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap3none/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap3none/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap4none/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap4none/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiofastforward/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiofastforward/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomedia/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomedia/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomute/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomute/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiopause/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiopause/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiorewind/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiorewind/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.away/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.away/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessdown/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessdown/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessup/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessup/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calculator/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calculator/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calendar/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calendar/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.capslock/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.capslock/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别，1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.defaultterminal/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.defaultterminal/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.displayswitch/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.displayswitch/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.documents/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.documents/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.eject/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.eject/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.homepage/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.homepage/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightdown/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightdown/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlighttoggle/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlighttoggle/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightup/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightup/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mail/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mail/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.medianext/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.medianext/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaplay/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaplay/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaprev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaprev/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediastop/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediastop/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.micmute/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.micmute/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.music/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.music/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.numlock/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.numlock/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别，1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.pictures/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.pictures/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.power/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.power/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.tools/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.tools/org.deepin.shortcut.json
@@ -57,14 +57,14 @@
             "description": "触发动作,工具为打开控制中心"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadoff/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadoff/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadon/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadon/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadtoggle/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadtoggle/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.turnoffscreen/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.turnoffscreen/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.video/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.video/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumedown/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumedown/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumeup/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumeup/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.wlan/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.wlan/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": false,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.www/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.www/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.cancel-maximize/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.cancel-maximize/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.clipboard/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.clipboard/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.close-window/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.close-window/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.delay-screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.delay-screenshot/org.deepin.shortcut.json
@@ -62,12 +62,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.filemanager/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.filemanager/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.fullscreen-screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.fullscreen-screenshot/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.globalsearch/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.globalsearch/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.launcher/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.launcher/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.lockscreen/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.lockscreen/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.logout/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.logout/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.maximize/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.maximize/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.next-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.next-workspace/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.notificationcenter/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.notificationcenter/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.prev-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.prev-workspace/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot-ocr/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot-ocr/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-desktop/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-desktop/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-window-menu/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-window-menu/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.systemmonitor/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.systemmonitor/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-next/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.terminalquake/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.terminalquake/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-fpsdisplay/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-fpsdisplay/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-multitaskview/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-multitaskview/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.window-screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.window-screenshot/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-1/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-1/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-2/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-2/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-3/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-3/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-4/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-4/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-5/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-5/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-6/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-6/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="zh_CN">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -72,12 +72,52 @@
         <translation>显示窗口菜单</translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation>任务切换器</translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation>切换多任务视图</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation>窗口</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>工作空间</translation>
+    </message>
+    <message>
+        <source>Delay Screenshot</source>
+        <translation>延时截图</translation>
+    </message>
+    <message>
+        <source>File Manager</source>
+        <translation>文件管理器</translation>
+    </message>
+    <message>
+        <source>Fullscreen Screenshot</source>
+        <translation>全屏截图</translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation>全局搜索</translation>
+    </message>
+    <message>
+        <source>OCR Screenshot</source>
+        <translation>OCR截图</translation>
+    </message>
+    <message>
+        <source>Screenshot</source>
+        <translation>截图</translation>
+    </message>
+    <message>
+        <source>System Monitor</source>
+        <translation>系统监视器</translation>
+    </message>
+    <message>
+        <source>Window Screenshot</source>
+        <translation>窗口截图</translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/src/config/configloader.cpp
+++ b/src/plugin-qt/shortcut/src/config/configloader.cpp
@@ -228,7 +228,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             return;
         }
 
-        configCanNotChanged = keyConfig.category == Category::System && !keyConfig.modifiable;
+        configCanNotChanged = !keyConfig.modifiable;
         qDebug() << "Parsed KeyConfig:" << keyConfig.appId << keyConfig.hotkeys << subPath;
         m_loadedSubPaths.insert(subPath);
         m_keys.append(keyConfig);
@@ -250,7 +250,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             return;
         }
 
-        configCanNotChanged = gestureConfig.category == Category::System && !gestureConfig.modifiable;
+        configCanNotChanged = !gestureConfig.modifiable;
         qDebug() << "Parsed GestureConfig:" << gestureConfig.appId << subPath;
         m_loadedSubPaths.insert(subPath);
         m_gestures.append(gestureConfig);
@@ -310,9 +310,9 @@ KeyConfig ConfigLoader::parseKeyConfig(DConfig *config)
     keyConfig.modifiable = config->value("modifiable").toBool();
     keyConfig.triggerType = config->value("triggerType").toInt();
     keyConfig.triggerValue = config->value("triggerValue").toStringList();
-    keyConfig.category = config->value("category").toInt(); 
+    keyConfig.category = config->value("category").toString();
     keyConfig.hotkeys = config->value("hotkeys").toStringList();
-    
+
     if (config->keyList().contains("keyEventFlags")) {
         // Parse keyEventFlags, default to Release (0x2) if not specified
         keyConfig.keyEventFlags = config->value("keyEventFlags", KeyEventFlag::Release).toInt();
@@ -331,7 +331,7 @@ GestureConfig ConfigLoader::parseGestureConfig(DConfig *config)
     gestureConfig.modifiable = config->value("modifiable").toBool();
     gestureConfig.triggerType = config->value("triggerType").toInt();
     gestureConfig.triggerValue = config->value("triggerValue").toStringList();
-    gestureConfig.category = config->value("category").toInt();
+    gestureConfig.category = config->value("category").toString();
     gestureConfig.gestureType = config->value("gestureType").toInt();
     gestureConfig.fingerCount = config->value("fingerCount").toInt();
     gestureConfig.direction = config->value("direction").toInt();

--- a/src/plugin-qt/shortcut/src/core/gesturemanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/gesturemanager.cpp
@@ -79,7 +79,9 @@ QList<GestureInfo> GestureManager::ListAllGestures()
         info.direction = config.direction;
         info.triggerType = config.triggerType;
         info.triggerValue = config.triggerValue;
+        info.isCustom = (config.category == CategoryKey::Custom);
         info.localLanguageName = m_translationManager->translate(config.appId, config.displayName);
+        info.localLanguageCategory = m_translationManager->translate(config.appId, config.category);
         list.append(info);
     }
     return list;

--- a/src/plugin-qt/shortcut/src/core/gesturemanager.h
+++ b/src/plugin-qt/shortcut/src/core/gesturemanager.h
@@ -21,13 +21,15 @@ class TranslationManager;
 struct GestureInfo {
     QString id;
     QString displayName;
-    int category;
+    QString category;
     int gestureType;
     int fingerCount;
     int direction;
     int triggerType;
     QStringList triggerValue;
     QString localLanguageName;
+    QString localLanguageCategory;
+    bool isCustom = false;
 };
 Q_DECLARE_METATYPE(GestureInfo)
 
@@ -84,14 +86,14 @@ Q_DECLARE_METATYPE(QList<GestureInfo>)
 
 inline QDBusArgument &operator<<(QDBusArgument &argument, const GestureInfo &info) {
     argument.beginStructure();
-    argument << info.id << info.displayName << info.category << info.gestureType << info.fingerCount << info.direction << info.triggerType << info.triggerValue << info.localLanguageName;
+    argument << info.id << info.displayName << info.category << info.gestureType << info.fingerCount << info.direction << info.triggerType << info.triggerValue << info.localLanguageName << info.localLanguageCategory << info.isCustom;
     argument.endStructure();
     return argument;
 }
 
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, GestureInfo &info) {
     argument.beginStructure();
-    argument >> info.id >> info.displayName >> info.category >> info.gestureType >> info.fingerCount >> info.direction >> info.triggerType >> info.triggerValue >> info.localLanguageName;
+    argument >> info.id >> info.displayName >> info.category >> info.gestureType >> info.fingerCount >> info.direction >> info.triggerType >> info.triggerValue >> info.localLanguageName >> info.localLanguageCategory >> info.isCustom;
     argument.endStructure();
     return argument;
 }

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -13,6 +13,7 @@
 
 #include <QDebug>
 #include <QDBusConnection>
+#include <QHash>
 
 #include <algorithm>
 
@@ -64,6 +65,11 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
 
     qDBusRegisterMetaType<ShortcutInfo>();
     qDBusRegisterMetaType<QList<ShortcutInfo>>();
+
+    qRegisterMetaType<CategoryInfo>("CategoryInfo");
+    qRegisterMetaType<QList<CategoryInfo>>("QList<CategoryInfo>");
+    qDBusRegisterMetaType<CategoryInfo>();
+    qDBusRegisterMetaType<QList<CategoryInfo>>();
 
     // Connect signals from key handler
     connect(m_keyHandler, &AbstractKeyHandler::keyActivated, this, &KeybindingManager::onKeyActivated);
@@ -135,7 +141,7 @@ QList<ShortcutInfo> KeybindingManager::ListShortcutsByApp(const QString &appId)
     return list;
 }
 
-QList<ShortcutInfo> KeybindingManager::ListShortcutsByCategory(int category)
+QList<ShortcutInfo> KeybindingManager::ListShortcutsByCategory(const QString &category)
 {
     QList<ShortcutInfo> list;
     QList<KeyConfig> configs = m_keyConfigsMap.values();
@@ -146,6 +152,53 @@ QList<ShortcutInfo> KeybindingManager::ListShortcutsByCategory(int category)
     }
 
     return list;
+}
+
+// Fixed display order for framework-reserved categories. The service owns
+// these, so it is entitled to define their canonical sequence. App-defined
+// categories slot in after Workspace and before Custom (which is always last).
+static const QHash<QString, int> &reservedCategoryOrder()
+{
+    static const QHash<QString, int> order{
+        {QStringLiteral("System"),     0},
+        {QStringLiteral("Window"),     1},
+        {QStringLiteral("Workspace"),  2},
+        {QStringLiteral("Custom"),     99},   // always last
+    };
+    return order;
+}
+
+QList<CategoryInfo> KeybindingManager::ListCategories()
+{
+    // Collect distinct categories from the user-visible (modifiable, with
+    // hotkeys) configs — mirrors ListAllShortcuts' filter so the category
+    // set matches what the control center actually renders.
+    QHash<QString, CategoryInfo> seen;
+    int appOrder = 10;  // app-defined categories land after Workspace(2), before Custom(99)
+    for (const auto &config : m_keyConfigsMap) {
+        if (!config.modifiable || config.category.isEmpty())
+            continue;
+        if (!seen.contains(config.category)) {
+            CategoryInfo ci;
+            ci.key = config.category;
+            ci.displayName = m_translationManager->translate(config.appId, config.category);
+            ci.isCustom = (config.category == CategoryKey::Custom);
+            const auto &reserved = reservedCategoryOrder();
+            if (reserved.contains(config.category)) {
+                ci.order = reserved.value(config.category);
+            } else {
+                ci.order = appOrder++;   // first-seen order for app-defined
+            }
+            seen.insert(config.category, ci);
+        }
+    }
+
+    QList<CategoryInfo> result = seen.values();
+    std::sort(result.begin(), result.end(),
+              [](const CategoryInfo &a, const CategoryInfo &b) {
+        return a.order < b.order;
+    });
+    return result;
 }
 
 ShortcutInfo KeybindingManager::GetShortcut(const QString &id)
@@ -713,6 +766,8 @@ ShortcutInfo KeybindingManager::toShortcutInfo(const KeyConfig &config)
         }
     }
     info.localLanguageName = m_translationManager->translate(config.appId, config.displayName);
+    info.isCustom = (config.category == CategoryKey::Custom);
+    info.localLanguageCategory = m_translationManager->translate(config.appId, config.category);
     return info;
 }
 

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -22,11 +22,23 @@ class TranslationManager;
 struct ShortcutInfo {
     QString id;
     QString displayName;
-    int category;
+    QString category;
     QStringList hotkeys;
     QString localLanguageName;
+    QString localLanguageCategory;
+    bool isCustom = false;
 };
 Q_DECLARE_METATYPE(ShortcutInfo)
+
+// Category metadata for the ListCategories() interface.
+struct CategoryInfo {
+    QString key;                    // Logical category key
+    QString displayName;            // Resolved display text
+    int order = 0;                  // Display order (lower = earlier)
+    bool isCustom = false;          // True for the user-editable category
+};
+Q_DECLARE_METATYPE(CategoryInfo)
+Q_DECLARE_METATYPE(QList<CategoryInfo>)
 
 class KeybindingManager : public QObject, protected QDBusContext
 {
@@ -59,7 +71,9 @@ public slots:
     // DBus Methods
     Q_SCRIPTABLE QList<ShortcutInfo> ListAllShortcuts();
     Q_SCRIPTABLE QList<ShortcutInfo> ListShortcutsByApp(const QString &appId);
-    Q_SCRIPTABLE QList<ShortcutInfo> ListShortcutsByCategory(int category);
+    Q_SCRIPTABLE QList<ShortcutInfo> ListShortcutsByCategory(const QString &category);
+
+    Q_SCRIPTABLE QList<CategoryInfo> ListCategories();
 
     Q_SCRIPTABLE ShortcutInfo GetShortcut(const QString &id);
     Q_SCRIPTABLE ShortcutInfo LookupConflictShortcut(const QString &hotkey);
@@ -120,14 +134,30 @@ Q_DECLARE_METATYPE(QList<ShortcutInfo>)
 
 inline QDBusArgument &operator<<(QDBusArgument &argument, const ShortcutInfo &info) {
     argument.beginStructure();
-    argument << info.id << info.displayName << info.category << info.hotkeys << info.localLanguageName;
+    argument << info.id << info.displayName << info.category << info.hotkeys
+             << info.localLanguageName << info.localLanguageCategory << info.isCustom;
     argument.endStructure();
     return argument;
 }
 
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, ShortcutInfo &info) {
     argument.beginStructure();
-    argument >> info.id >> info.displayName >> info.category >> info.hotkeys >> info.localLanguageName;
+    argument >> info.id >> info.displayName >> info.category >> info.hotkeys
+             >> info.localLanguageName >> info.localLanguageCategory >> info.isCustom;
+    argument.endStructure();
+    return argument;
+}
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const CategoryInfo &info) {
+    argument.beginStructure();
+    argument << info.key << info.displayName << info.order << info.isCustom;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, CategoryInfo &info) {
+    argument.beginStructure();
+    argument >> info.key >> info.displayName >> info.order >> info.isCustom;
     argument.endStructure();
     return argument;
 }

--- a/src/plugin-qt/shortcut/src/core/shortcutconfig.h
+++ b/src/plugin-qt/shortcut/src/core/shortcutconfig.h
@@ -21,11 +21,13 @@ namespace KeyEventFlag {
     constexpr int Repeat = 0x4;  // Trigger on key repeat (auto-repeat)
 }
 
-enum Category {
-    System = 1,
-    App,
-    Custom
-};
+// Framework-reserved shortcut categories.
+namespace CategoryKey {
+    inline constexpr const char *System = "System";
+    inline constexpr const char *Window = "Window";
+    inline constexpr const char *Workspace = "Workspace";
+    inline constexpr const char *Custom = "Custom";
+}
 
 // Base configuration information
 struct BaseConfig
@@ -33,7 +35,7 @@ struct BaseConfig
     QString appId;              // Application ID
     QString subPath;            // DConfig subPath (e.g. [appId].shortcut.xxx)
     QString displayName;        // Localized name
-    int category;               // 1: System, 2: App, 3: Custom
+    QString category;           // Logical category key (e.g. "System", "Window", app-defined)
     bool enabled;
     bool modifiable;
     int triggerType;            // 1: Command, 2: App, 3: Action

--- a/src/plugin-qt/shortcut/tools/extract_shortcuts_i18n.py
+++ b/src/plugin-qt/shortcut/tools/extract_shortcuts_i18n.py
@@ -11,10 +11,12 @@ import sys
 def extract_translations(config_dir, output_file, app_id):
     """
     Scans the config_dir for org.deepin.shortcut.json / org.deepin.gesture.json
-    files and extracts the displayName field into a dummy C++ file for lupdate scanning.
+    files and extracts the displayName and category fields into a dummy C++ file
+    for lupdate scanning. Both fields use the same translation model: the app
+    that provides the config provides the translation via its per-appId QM.
     """
     # Fixed display text used when a shortcut has no assigned key sequence.
-    display_names = {"None"}
+    translatable = {"None"}
     target_files = {"org.deepin.shortcut.json", "org.deepin.gesture.json"}
 
     for root, dirs, files in os.walk(config_dir):
@@ -25,20 +27,23 @@ def extract_translations(config_dir, output_file, app_id):
                         data = json.load(f)
                         contents = data.get("contents", {})
 
-                        # Check if modifiable is true
+                        # Only extract from modifiable (user-visible) configs
                         modifiable = contents.get("modifiable", {}).get("value", False)
                         if not modifiable:
                             continue
 
-                        # Extract displayName only if modifiable is true
                         display_name = contents.get("displayName", {}).get("value")
                         if display_name:
-                            display_names.add(display_name)
+                            translatable.add(display_name)
+
+                        category = contents.get("category", {}).get("value")
+                        if category and isinstance(category, str):
+                            translatable.add(category)
                     except Exception as e:
                         print(f"Error parsing {file}: {e}", file=sys.stderr)
 
-    if not display_names:
-        print(f"Warning: No shortcut definitions found in {config_dir}", file=sys.stderr)
+    if not translatable:
+        print(f"Warning: No translatable strings found in {config_dir}", file=sys.stderr)
 
     with open(output_file, 'w') as f:
         f.write('// This is an automatically generated file for shortcut translation extraction.\n')
@@ -47,7 +52,7 @@ def extract_translations(config_dir, output_file, app_id):
         f.write('// Mark strings for translation using QT_TRANSLATE_NOOP\n')
         f.write('// The array is marked as unused to suppress compiler warnings\n')
         f.write('[[maybe_unused]] static const char* shortcut_names[] = {\n')
-        for name in sorted(display_names):
+        for name in sorted(translatable):
             f.write(f'    QT_TRANSLATE_NOOP("{app_id}", "{name}"),\n')
         f.write('};\n')
 

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_en.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_en.ts
@@ -12,6 +12,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_CN.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_CN.ts
@@ -12,6 +12,22 @@
         <translation>终端</translation>
     </message>
     <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation>窗口</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>工作空间</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>自定义</translation>
+    </message>
+    <message>
         <source>None</source>
         <translation>无</translation>
     </message>


### PR DESCRIPTION
## Summary
- Add string-based shortcut categories and ListCategories D-Bus metadata for Wayland.
- Translate category display names through each shortcut provider's i18n domain.
- Update shortcut DConfig category values and generated translation sources.

## Test plan
- Verified by user.
- Ran git diff --check.
- Ran shortcut i18n update target and generated dde-app zh_CN QM with 29 finished translations.

Log: add dynamic category metadata
Pms: BUG-367657,BUG-365993

## Summary by Sourcery

Introduce string-based shortcut categories and expose localized category metadata over D-Bus for shortcuts and gestures.

New Features:
- Add ListCategories D-Bus API returning category metadata including key, display name, order, and custom flag.
- Expose localized category names and custom-category markers in ShortcutInfo and GestureInfo for consumers.

Enhancements:
- Migrate shortcut and gesture category fields from numeric enums to logical string keys, including reserved framework categories.
- Adjust config loading and immutability rules to rely solely on the modifiable flag instead of system-category checks.
- Update i18n extraction tooling to collect translations for both shortcut display names and category keys.
- Extend keybinding and dde-app translation catalogs with category strings such as System, Window, Workspace, and Custom, plus additional shortcut-related texts.