### PR TITLE
fix(power): reschedule idle tasks

### DIFF
--- a/src/plugin-qt/power/session/powersaveplan.cpp
+++ b/src/plugin-qt/power/session/powersaveplan.cpp
@@ -124,14 +124,24 @@ void PowerSavePlan::Update(int screenSaverStartDelay, int lockDelay,
         }
     }
 
-    setScreenSaverTimeout(min);
-
-    for (auto &t : m_metaTasks) {
-        int nSecs = t.delay - min;
-        t.realDelay = nSecs > 0 ? nSecs * 1000 : 1;
+    
+    bool isIdle = false;
+    if (m_powerManager) {
+        auto *iw = m_powerManager->idleWatcher();
+        isIdle = iw && iw->isIdle();
     }
-
-    if (m_isIdle) {
+    
+    for (auto &t : m_metaTasks) {
+        if (isIdle) { // 已经处于 idleon 状态的update（可能是插拔电源或者用户重新设置延迟）, 重排任务
+            t.realDelay = t.delay > 0 ? t.delay * 1000 : 1;
+        } else { // 到达 idleOn 后立即执行动作
+            int nSecs = t.delay - min;
+            t.realDelay = nSecs > 0 ? nSecs * 1000 : 1;
+        }
+    }
+    
+    setScreenSaverTimeout(min);
+    if (isIdle) {
         HandleIdleOn();
     }
 }
@@ -149,8 +159,6 @@ void PowerSavePlan::HandleIdleOn()
         return;
     }
 
-    m_isIdle = true;
-
     for (const auto &t : m_metaTasks) {
         scheduleTask(t);
     }
@@ -162,7 +170,6 @@ void PowerSavePlan::HandleIdleOn()
 void PowerSavePlan::HandleIdleOff()
 {
     qDebug(logPowerSession) << "HandleIdleOff";
-    m_isIdle = false;
     interruptTasks();
     if (!m_powerManager) return;
     m_powerManager->SetPrepareSuspend(static_cast<int>(PS_Normal));
@@ -174,7 +181,7 @@ void PowerSavePlan::HandleIdleOff()
 
 void PowerSavePlan::scheduleTask(const MetaTask &t)
 {
-    qDebug(logPowerSession) << "Scheduling task" << t.name << "to run in" << t.realDelay << "ms";
+    qWarning(logPowerSession) << "Scheduling task" << t.name << "to run in" << t.realDelay << "ms";
     auto *timer = new QTimer(this);
     timer->setSingleShot(true);
     connect(timer, &QTimer::timeout, this, t.fn);

--- a/src/plugin-qt/power/session/powersaveplan.h
+++ b/src/plugin-qt/power/session/powersaveplan.h
@@ -52,7 +52,6 @@ private:
     QVector<QTimer *> m_timers;
     QMap<QString, double> m_oldBrightness;
     bool m_screensaverRunning = false;
-    bool m_isIdle = false;
     bool m_allowScreenSaver = true;
     bool m_psmEnabled = false;
     uint m_psmDrop = 0;


### PR DESCRIPTION
1. Query the current idle state from IdleWatcher when updating the power save plan.
2. Recalculate task delays differently when the session is already idle.
3. Drop the duplicated PowerSavePlan idle state to avoid stale scheduling decisions.

Log: Reschedule power save tasks correctly when the idle state is already active.

fix(power): 修复 idle 任务重排

1. 更新节能计划时从 IdleWatcher 查询当前 idle 状态。
2. 会话已处于 idle 状态时按任务自身延迟重新计算定时任务。
3. 移除 PowerSavePlan 重复维护的 idle 状态，避免使用过期状态调度任务。

Log: 已处于 idle 状态时正确重排节能任务。