### PR TITLE
feat(shortcut): add custom shortcut CRUD persistence

### DIFF
--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SHORTCUT_COMMON_SOURCES
     ${SHORTCUT_SRC_DIR}/core/actionexecutor.cpp
     ${SHORTCUT_SRC_DIR}/core/translationmanager.cpp
     ${SHORTCUT_SRC_DIR}/config/configloader.cpp
+    ${SHORTCUT_SRC_DIR}/config/customshortcutstore.cpp
     ${SHORTCUT_SRC_DIR}/backend/abstractkeyhandler.h
     ${SHORTCUT_SRC_DIR}/backend/abstractgesturehandler.h
     ${SHORTCUT_SRC_DIR}/backend/specialkeyhandler.cpp
@@ -112,6 +113,12 @@ foreach(SUBDIR_PATH ${SHORTCUT_CONFIG_SUBDIRS})
         FILES "${SUBDIR_PATH}/org.deepin.shortcut.json"
     )
 endforeach()
+
+# install base json config
+dtk_add_config_meta_files(
+    APPID "org.deepin.dde.keybinding"
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/configs/org.deepin.shortcut.json"
+)
 
 foreach(SUBDIR_PATH ${GESTURE_CONFIG_SUBDIRS})
     dtk_add_config_meta_files(

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3down/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3down/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3left/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3left/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3right/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3right/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3up/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe3up/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4down/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4down/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4left/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4left/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4right/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4right/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4up/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.swipe4up/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap3none/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap3none/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap4none/org.deepin.gesture.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.gesture.tap4none/org.deepin.gesture.json
@@ -73,12 +73,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiofastforward/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiofastforward/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomedia/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomedia/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomute/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiomute/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiopause/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiopause/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiorewind/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.audiorewind/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.away/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.away/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessdown/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessdown/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessup/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.brightnessup/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calculator/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calculator/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calendar/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.calendar/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.capslock/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.capslock/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别，1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.defaultterminal/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.defaultterminal/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.displayswitch/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.displayswitch/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.documents/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.documents/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.eject/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.eject/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.homepage/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.homepage/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightdown/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightdown/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlighttoggle/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlighttoggle/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightup/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.kbdlightup/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mail/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mail/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.medianext/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.medianext/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaplay/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaplay/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaprev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediaprev/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediastop/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.mediastop/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.micmute/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.micmute/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.music/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.music/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.numlock/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.numlock/org.deepin.shortcut.json
@@ -59,8 +59,8 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "name[zh_CN]": "快捷键类别，1:系统",

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.pictures/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.pictures/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.power/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.power/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.tools/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.tools/org.deepin.shortcut.json
@@ -57,14 +57,14 @@
             "description": "触发动作,工具为打开控制中心"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": true,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadoff/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadoff/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadon/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadon/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadtoggle/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.touchpadtoggle/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.turnoffscreen/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.turnoffscreen/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.video/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.video/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumedown/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumedown/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumeup/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.volumeup/org.deepin.shortcut.json
@@ -69,12 +69,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.wlan/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.wlan/org.deepin.shortcut.json
@@ -59,14 +59,14 @@
             "description": "触发动作"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
             "permissions": "",
             "visibility": "private",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键"
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category"
         },
         "enabled": {
             "value": false,

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.www/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.www/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/configs/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.shortcut.json
@@ -1,0 +1,86 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "appId": {
+            "value": "org.deepin.dde.keybinding",
+            "serial": 0,
+            "flags": [],
+            "name": "appId",
+            "name[zh_CN]": "提供快捷键应用Id",
+            "description": "provide shortcut app id",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "displayName": {
+            "value": "",
+            "serial": 0,
+            "flags": [],
+            "name": "displayName",
+            "name[zh_CN]": "",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "hotkeys": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "hotkeys",
+            "name[zh_CN]": "快捷键组合",
+            "description": "打开默认终端快捷键组合",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "triggerType": {
+            "value": 1,
+            "serial": 0,
+            "flags": [],
+            "name": "triggerType",
+            "name[zh_CN]": "快捷键触发动作类型",
+            "description": "二进制command类型",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "triggerValue": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "triggerValue",
+            "name[zh_CN]": "快捷键触发动作",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "category": {
+            "value": "Custom",
+            "serial": 1,
+            "flags": [],
+            "name": "category",
+            "name[zh_CN]": "快捷键类别（Custom）",
+            "description": "Custom shortcut category",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "enabled": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "enabled",
+            "name[zh_CN]": "使能",
+            "description": "是否启用快捷键",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "modifiable": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "modifiable",
+            "name[zh_CN]": "能否修改快捷键",
+            "description": "不能修改快捷键",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.cancel-maximize/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.cancel-maximize/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.clipboard/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.clipboard/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.close-window/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.close-window/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.delay-screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.delay-screenshot/org.deepin.shortcut.json
@@ -62,12 +62,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.filemanager/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.filemanager/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.fullscreen-screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.fullscreen-screenshot/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.globalsearch/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.globalsearch/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.launcher/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.launcher/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.lockscreen/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.lockscreen/org.deepin.shortcut.json
@@ -59,12 +59,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.logout/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.logout/org.deepin.shortcut.json
@@ -60,12 +60,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.maximize/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.maximize/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.next-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.next-workspace/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.notificationcenter/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.notificationcenter/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.prev-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.prev-workspace/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot-ocr/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot-ocr/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-desktop/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-desktop/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-window-menu/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-window-menu/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.systemmonitor/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.systemmonitor/org.deepin.shortcut.json
@@ -57,12 +57,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-next/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Window",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.terminalquake/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.terminalquake/org.deepin.shortcut.json
@@ -58,12 +58,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-fpsdisplay/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-fpsdisplay/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-multitaskview/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-multitaskview/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.window-screenshot/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.window-screenshot/org.deepin.shortcut.json
@@ -61,12 +61,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "System",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（System）",
+            "description": "System shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-1/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-1/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-2/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-2/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-3/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-3/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-4/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-4/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-5/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-5/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-6/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.workspace-6/org.deepin.shortcut.json
@@ -67,12 +67,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": 1,
-            "serial": 0,
+            "value": "Workspace",
+            "serial": 1,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别,1:系统",
-            "description": "系统快捷键",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="zh_CN">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -72,12 +72,52 @@
         <translation>显示窗口菜单</translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation>任务切换器</translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation>切换多任务视图</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation>窗口</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>工作空间</translation>
+    </message>
+    <message>
+        <source>Delay Screenshot</source>
+        <translation>延时截图</translation>
+    </message>
+    <message>
+        <source>File Manager</source>
+        <translation>文件管理器</translation>
+    </message>
+    <message>
+        <source>Fullscreen Screenshot</source>
+        <translation>全屏截图</translation>
+    </message>
+    <message>
+        <source>Global Search</source>
+        <translation>全局搜索</translation>
+    </message>
+    <message>
+        <source>OCR Screenshot</source>
+        <translation>OCR截图</translation>
+    </message>
+    <message>
+        <source>Screenshot</source>
+        <translation>截图</translation>
+    </message>
+    <message>
+        <source>System Monitor</source>
+        <translation>系统监视器</translation>
+    </message>
+    <message>
+        <source>Window Screenshot</source>
+        <translation>窗口截图</translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
@@ -72,10 +72,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Task Switcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Toggle Multitask View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,6 +105,18 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/src/config/configloader.cpp
+++ b/src/plugin-qt/shortcut/src/config/configloader.cpp
@@ -213,7 +213,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             return;
         }
 
-        configCanNotChanged = keyConfig.category == Category::System && !keyConfig.modifiable;
+        configCanNotChanged = !keyConfig.modifiable;
         qDebug() << "Parsed KeyConfig:" << keyConfig.appId << keyConfig.hotkeys << subPath;
         m_loadedSubPaths.insert(subPath);
         m_keys.append(keyConfig);
@@ -235,7 +235,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             return;
         }
 
-        configCanNotChanged = gestureConfig.category == Category::System && !gestureConfig.modifiable;
+        configCanNotChanged = !gestureConfig.modifiable;
         qDebug() << "Parsed GestureConfig:" << gestureConfig.appId << subPath;
         m_loadedSubPaths.insert(subPath);
         m_gestures.append(gestureConfig);
@@ -295,9 +295,9 @@ KeyConfig ConfigLoader::parseKeyConfig(DConfig *config)
     keyConfig.modifiable = config->value("modifiable").toBool();
     keyConfig.triggerType = config->value("triggerType").toInt();
     keyConfig.triggerValue = config->value("triggerValue").toStringList();
-    keyConfig.category = config->value("category").toInt(); 
+    keyConfig.category = config->value("category").toString();
     keyConfig.hotkeys = config->value("hotkeys").toStringList();
-    
+
     if (config->keyList().contains("keyEventFlags")) {
         // Parse keyEventFlags, default to Release (0x2) if not specified
         keyConfig.keyEventFlags = config->value("keyEventFlags", KeyEventFlag::Release).toInt();
@@ -316,7 +316,7 @@ GestureConfig ConfigLoader::parseGestureConfig(DConfig *config)
     gestureConfig.modifiable = config->value("modifiable").toBool();
     gestureConfig.triggerType = config->value("triggerType").toInt();
     gestureConfig.triggerValue = config->value("triggerValue").toStringList();
-    gestureConfig.category = config->value("category").toInt();
+    gestureConfig.category = config->value("category").toString();
     gestureConfig.gestureType = config->value("gestureType").toInt();
     gestureConfig.fingerCount = config->value("fingerCount").toInt();
     gestureConfig.direction = config->value("direction").toInt();

--- a/src/plugin-qt/shortcut/src/config/configloader.cpp
+++ b/src/plugin-qt/shortcut/src/config/configloader.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "configloader.h"
-#include "core/shortcutconfig.h"
 
 #include <algorithm>
 
@@ -23,6 +22,12 @@ const QString CONFIG_NAME_GESTURE = "org.deepin.gesture";
 const QString CONFIG_SUBPATH_DIR = "/usr/share/deepin/org.deepin.dde.keybinding/";
 
 DCORE_USE_NAMESPACE
+
+static DConfig *createDConfig(const QString &name, const QString &subPath, QObject *parent)
+{
+    const QString normalized = CustomShortcutStore::normalizeSubPath(subPath);
+    return DConfig::create(APP_ID, name, QStringLiteral("/") + normalized, parent);
+}
 
 ConfigLoader::ConfigLoader(QObject *parent)
     : QObject(parent)
@@ -93,22 +98,36 @@ void ConfigLoader::resetConfig()
     }
 }
 
-void ConfigLoader::updateValue(const QString &id, const QString &key, const QVariant &value)
+bool ConfigLoader::updateValue(const QString &id, const QString &key, const QVariant &value)
 {
     if (!m_configs.contains(id)) {
         qWarning() << "ConfigLoader: config not found or can not be changed:" << id << key << value;
-        return;
+        return false;
     }
     
     m_configs[id]->setValue(key, value);
+    return true;
+}
+
+bool ConfigLoader::canUpdateValue(const QString &id) const
+{
+    return m_configs.contains(id);
 }
 
 QSet<QString> ConfigLoader::discoverSubPaths()
 {
-    // Accumulate all found subpaths
+    QSet<QString> foundSubPaths;
+    foundSubPaths.unite(scanIniSubPaths(CONFIG_SUBPATH_DIR));
+    foundSubPaths.unite(m_customStore.discoverSubPaths());
+
+    return foundSubPaths;
+}
+
+QSet<QString> ConfigLoader::scanIniSubPaths(const QString &dirPath)
+{
     QSet<QString> foundSubPaths;
 
-    QDir regDir(CONFIG_SUBPATH_DIR);
+    QDir regDir(dirPath);
     if (!regDir.exists()) {
         return foundSubPaths;
     }
@@ -119,7 +138,7 @@ QSet<QString> ConfigLoader::discoverSubPaths()
     static const QRegularExpression reContinuation(QStringLiteral("\\\\\\s*\\n"));
     QStringList iniFiles = regDir.entryList(QStringList() << "*.ini", QDir::Files | QDir::NoDotAndDotDot);
     for (const QString &iniFile : iniFiles) {
-        QString fullPath = QDir(CONFIG_SUBPATH_DIR).absoluteFilePath(iniFile);
+        QString fullPath = regDir.absoluteFilePath(iniFile);
         QFile file(fullPath);
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
             qWarning() << "ConfigLoader: Failed to open" << fullPath;
@@ -169,6 +188,119 @@ QSet<QString> ConfigLoader::discoverSubPaths()
     return foundSubPaths;
 }
 
+bool ConfigLoader::saveCustomShortcut(const KeyConfig &config)
+{
+    const QString subPath = CustomShortcutStore::normalizeSubPath(config.subPath);
+    DConfig *customDconfig = m_configs.value(subPath);
+    const bool existingDConfig = customDconfig;
+    if (!customDconfig) {
+        customDconfig = m_customStore.createConfig(subPath, this);
+        if (!customDconfig->isValid()) {
+            qWarning() << "ConfigLoader: failed to create custom shortcut DConfig:" << subPath;
+            delete customDconfig;
+            return false;
+        }
+    }
+
+    KeyConfig storedConfig = config;
+    storedConfig.subPath = subPath;
+    if (!m_customStore.save(storedConfig, customDconfig)) {
+        if (!existingDConfig) {
+            m_customStore.reset(customDconfig, subPath);
+            customDconfig->deleteLater();
+        }
+        return false;
+    }
+
+    auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                 [&](const KeyConfig &item) { return item.subPath == subPath; });
+    if (existing != m_keys.end())
+        *existing = storedConfig;
+    else
+        m_keys.append(storedConfig);
+
+    m_loadedSubPaths.insert(subPath);
+    if (!m_configs.contains(subPath)) {
+        connect(customDconfig, &DConfig::valueChanged, this, [this, subPath, customDconfig](const QString &key) {
+            if (!customDconfig->isValid() || !m_configs.contains(subPath)) {
+                qWarning() << "DConfig invalid or not found:" << subPath;
+                return;
+            }
+
+            KeyConfig updatedConfig = parseKeyConfig(customDconfig);
+            qDebug() << "DConfig value changed:" << subPath << key;
+            auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                         [&](const KeyConfig &item) { return item.subPath == subPath; });
+            if (existing != m_keys.end()) {
+                *existing = updatedConfig;
+            } else {
+                m_keys.append(updatedConfig);
+            }
+            emit keyConfigChanged(updatedConfig);
+        });
+        m_configs.insert(subPath, customDconfig);
+    }
+
+    return true;
+}
+
+bool ConfigLoader::updateCustomShortcut(const KeyConfig &config)
+{
+    const QString subPath = CustomShortcutStore::normalizeSubPath(config.subPath);
+    DConfig *customDconfig = m_configs.value(subPath);
+    if (!customDconfig) {
+        qWarning() << "ConfigLoader: custom shortcut config not found for update:" << subPath;
+        return false;
+    }
+
+    KeyConfig storedConfig = config;
+    storedConfig.subPath = subPath;
+    if (!m_customStore.updateCustomShortcutFields(storedConfig, customDconfig))
+        return false;
+
+    auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                 [&](const KeyConfig &item) { return item.subPath == subPath; });
+    if (existing != m_keys.end())
+        *existing = storedConfig;
+    else
+        m_keys.append(storedConfig);
+
+    m_loadedSubPaths.insert(subPath);
+    return true;
+}
+
+bool ConfigLoader::removeCustomShortcut(const QString &subPath)
+{
+    const QString normalized = CustomShortcutStore::normalizeSubPath(subPath);
+    DConfig *config = m_configs.take(normalized);
+    if (!config) {
+        config = m_customStore.createConfig(normalized, this);
+        if (!config->isValid()) {
+            qWarning() << "ConfigLoader: failed to create custom shortcut DConfig for reset:" << normalized;
+            delete config;
+            return false;
+        }
+    } else {
+        disconnect(config, nullptr, this, nullptr);
+    }
+
+    m_customStore.reset(config, normalized);
+    if (!m_customStore.removeSubPath(normalized)) {
+        qWarning() << "ConfigLoader: failed to remove custom shortcut subPath after reset,"
+                   << "leaving a stale ini entry:" << normalized;
+    }
+
+    m_loadedSubPaths.remove(normalized);
+    m_keys.erase(std::remove_if(m_keys.begin(), m_keys.end(),
+                                [&](const KeyConfig &config) { return config.subPath == normalized; }),
+                 m_keys.end());
+
+    if (config)
+        config->deleteLater();
+
+    return true;
+}
+
 void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
 {
     qDebug() << "Loading config from:" << subPath;
@@ -186,9 +318,8 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
         return;
     }
 
-    DConfig *config = DConfig::create(APP_ID,
-                                      isKey ? CONFIG_NAME_SHORTCUT : CONFIG_NAME_GESTURE,
-                                      "/" + subPath, this);
+    DConfig *config = createDConfig(isKey ? CONFIG_NAME_SHORTCUT : CONFIG_NAME_GESTURE,
+                                    subPath, this);
     if (!config->isValid()) {
         qWarning() << "Failed to create DConfig for" << subPath;
         delete config;
@@ -199,10 +330,6 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
     if (isKey) {
         KeyConfig keyConfig = parseKeyConfig(config);
         if (!keyConfig.isValid()) {
-            // isValid() requires enabled && non-empty appId/displayName/hotkeys.
-            // Most commonly this triggers for shipped-disabled hardware keys
-            // (e.g. wlan with enabled=false). Remember the subPath so reload()
-            // doesn't re-attempt and log this every dpkg trigger.
             qWarning() << "Skipping invalid or disabled KeyConfig:" << subPath
                        << "(enabled=" << keyConfig.enabled
                        << ", appId set=" << !keyConfig.appId.isEmpty()
@@ -257,20 +384,22 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             qDebug() << "DConfig value changed:" << subPath << key;
             if (isKey) {
                 KeyConfig updatedConfig = parseKeyConfig(config);
-                for (auto &existing : m_keys) {
-                    if (existing.subPath == subPath) {
-                        existing = updatedConfig;
-                        break;
-                    }
+                auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                             [&](const KeyConfig &item) { return item.subPath == subPath; });
+                if (existing != m_keys.end()) {
+                    *existing = updatedConfig;
+                } else {
+                    m_keys.append(updatedConfig);
                 }
                 emit keyConfigChanged(updatedConfig);
             } else {
                 GestureConfig updatedConfig = parseGestureConfig(config);
-                for (auto &existing : m_gestures) {
-                    if (existing.subPath == subPath) {
-                        existing = updatedConfig;
-                        break;
-                    }
+                auto existing = std::find_if(m_gestures.begin(), m_gestures.end(),
+                                             [&](const GestureConfig &item) { return item.subPath == subPath; });
+                if (existing != m_gestures.end()) {
+                    *existing = updatedConfig;
+                } else {
+                    m_gestures.append(updatedConfig);
                 }
                 emit gestureConfigChanged(updatedConfig);
             }
@@ -280,15 +409,10 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
     }
 }
 
-static QString normalizedSubpath(const QString &raw)
-{
-    return raw.startsWith(QLatin1Char('/')) ? raw.mid(1) : raw;
-}
-
 KeyConfig ConfigLoader::parseKeyConfig(DConfig *config)
 {
     KeyConfig keyConfig;
-    keyConfig.subPath = normalizedSubpath(config->subpath());
+    keyConfig.subPath = CustomShortcutStore::normalizeSubPath(config->subpath());
     keyConfig.appId = config->value("appId").toString();
     keyConfig.displayName = config->value("displayName").toString();
     keyConfig.enabled = config->value("enabled").toBool();
@@ -309,7 +433,7 @@ KeyConfig ConfigLoader::parseKeyConfig(DConfig *config)
 GestureConfig ConfigLoader::parseGestureConfig(DConfig *config)
 {
     GestureConfig gestureConfig;
-    gestureConfig.subPath = normalizedSubpath(config->subpath());
+    gestureConfig.subPath = CustomShortcutStore::normalizeSubPath(config->subpath());
     gestureConfig.appId = config->value("appId").toString();
     gestureConfig.displayName = config->value("displayName").toString();
     gestureConfig.enabled = config->value("enabled").toBool();

--- a/src/plugin-qt/shortcut/src/config/configloader.h
+++ b/src/plugin-qt/shortcut/src/config/configloader.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include "config/customshortcutstore.h"
 #include "core/shortcutconfig.h"
 
 #include <QObject>
 #include <QMap>
 #include <QList>
+#include <QSet>
 
 #include <DConfig>
 
@@ -28,8 +30,14 @@ public:
     void scanForConfigs();
     void reload();
     void resetConfig();
-    void updateValue(const QString &id, const QString &key, const QVariant &value);
+    bool updateValue(const QString &id, const QString &key, const QVariant &value);
+    bool canUpdateValue(const QString &id) const;
     void dumpConfigs();
+
+    // Custom shortcut persistence (user-level DConfig + INI)
+    bool saveCustomShortcut(const KeyConfig &config);
+    bool updateCustomShortcut(const KeyConfig &config);
+    bool removeCustomShortcut(const QString &subPath);
 
     QList<KeyConfig> keys() const { return m_keys; }
     QList<GestureConfig> gestures() const { return m_gestures; }
@@ -44,7 +52,7 @@ signals:
 
 private:
     QSet<QString> discoverSubPaths();
-    bool needLoad(const QString &subPath);
+    QSet<QString> scanIniSubPaths(const QString &dirPath);
     void loadConfig(const QString &subPath, bool newOne = false);
     KeyConfig parseKeyConfig(DConfig *config);
     GestureConfig parseGestureConfig(DConfig *config);
@@ -53,4 +61,6 @@ private:
     QList<GestureConfig> m_gestures;
     QMap<QString, DConfig*> m_configs; // subPath(id) -> config, key has no leading /
     QSet<QString> m_loadedSubPaths; // Track all loaded subPaths
+
+    CustomShortcutStore m_customStore;
 };

--- a/src/plugin-qt/shortcut/src/config/customshortcutstore.cpp
+++ b/src/plugin-qt/shortcut/src/config/customshortcutstore.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "customshortcutstore.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QSettings>
+#include <QSignalBlocker>
+#include <QStandardPaths>
+#include <QVariant>
+
+namespace {
+
+const QString APP_ID = "org.deepin.dde.keybinding";
+const QString CONFIG_NAME_SHORTCUT = "org.deepin.shortcut";
+const QString CUSTOM_CONFIG_SUBPATH_DIR = "deepin/dde-services/shortcut";
+const QString CUSTOM_CONFIG_INI = "custom-shortcuts.ini";
+
+const QStringList CustomShortcutKeys = {
+    QStringLiteral("appId"),
+    QStringLiteral("displayName"),
+    QStringLiteral("enabled"),
+    QStringLiteral("modifiable"),
+    QStringLiteral("triggerType"),
+    QStringLiteral("triggerValue"),
+    QStringLiteral("category"),
+    QStringLiteral("hotkeys")
+};
+
+} // namespace
+
+CustomShortcutStore::CustomShortcutStore()
+    : m_iniPath(QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation))
+                        .absoluteFilePath(CUSTOM_CONFIG_SUBPATH_DIR + QLatin1Char('/') + CUSTOM_CONFIG_INI))
+{
+}
+
+QSet<QString> CustomShortcutStore::discoverSubPaths() const
+{
+    QSet<QString> result;
+    const QFileInfo info(m_iniPath);
+    if (!info.exists())
+        return result;
+
+    const QStringList paths = subPaths();
+    for (const QString &subPath : paths)
+        result.insert(subPath);
+    return result;
+}
+
+DConfig *CustomShortcutStore::createConfig(const QString &subPath, QObject *parent) const
+{
+    const QString normalized = normalizeSubPath(subPath);
+    return DConfig::create(APP_ID, CONFIG_NAME_SHORTCUT, QStringLiteral("/") + normalized, parent);
+}
+
+bool CustomShortcutStore::save(const KeyConfig &config, DConfig *configObject) const
+{
+    if (!configObject) {
+        qWarning() << "CustomShortcutStore: missing DConfig object for save:" << config.subPath;
+        return false;
+    }
+
+    const QString subPath = normalizeSubPath(config.subPath);
+    qInfo() << "CustomShortcutStore: saving custom shortcut"
+            << "subPath:" << subPath
+            << "appId:" << config.appId
+            << "displayName:" << config.displayName
+            << "enabled:" << config.enabled
+            << "modifiable:" << config.modifiable
+            << "triggerType:" << config.triggerType
+            << "triggerValue count:" << config.triggerValue.size()
+            << "command length:" << (config.triggerValue.isEmpty() ? 0 : config.triggerValue.first().size())
+            << "category:" << config.category
+            << "hotkeys:" << config.hotkeys;
+
+    {
+        const QSignalBlocker blocker(configObject);
+        configObject->setValue("appId", config.appId);
+        configObject->setValue("displayName", config.displayName);
+        configObject->setValue("enabled", config.enabled);
+        configObject->setValue("modifiable", config.modifiable);
+        configObject->setValue("triggerType", config.triggerType);
+        configObject->setValue("triggerValue", config.triggerValue);
+        configObject->setValue("category", config.category);
+        configObject->setValue("hotkeys", config.hotkeys);
+    }
+
+    QStringList paths = subPaths();
+    if (!paths.contains(subPath))
+        paths.append(subPath);
+    return writeSubPaths(paths);
+}
+
+bool CustomShortcutStore::updateCustomShortcutFields(const KeyConfig &config, DConfig *configObject) const
+{
+    if (!configObject) {
+        qWarning() << "CustomShortcutStore: missing DConfig object for update:" << config.subPath;
+        return false;
+    }
+
+    const QString subPath = normalizeSubPath(config.subPath);
+    qInfo() << "CustomShortcutStore: updating custom shortcut fields"
+            << "subPath:" << subPath
+            << "displayName:" << config.displayName
+            << "triggerValue count:" << config.triggerValue.size()
+            << "command length:" << (config.triggerValue.isEmpty() ? 0 : config.triggerValue.first().size())
+            << "hotkeys:" << config.hotkeys;
+
+    const QSignalBlocker blocker(configObject);
+    const auto setIfChanged = [configObject](const QString &key, const QVariant &value) {
+        if (configObject->value(key) != value)
+            configObject->setValue(key, value);
+    };
+
+    setIfChanged(QStringLiteral("appId"), config.appId);
+    setIfChanged(QStringLiteral("displayName"), config.displayName);
+    setIfChanged(QStringLiteral("enabled"), config.enabled);
+    setIfChanged(QStringLiteral("modifiable"), config.modifiable);
+    setIfChanged(QStringLiteral("triggerType"), config.triggerType);
+    setIfChanged(QStringLiteral("triggerValue"), config.triggerValue);
+    setIfChanged(QStringLiteral("category"), config.category);
+    setIfChanged(QStringLiteral("hotkeys"), config.hotkeys);
+    return true;
+}
+
+bool CustomShortcutStore::removeSubPath(const QString &subPath) const
+{
+    QStringList paths = subPaths();
+    paths.removeAll(normalizeSubPath(subPath));
+    return writeSubPaths(paths);
+}
+
+void CustomShortcutStore::reset(DConfig *configObject, const QString &subPath) const
+{
+    if (!configObject)
+        return;
+
+    const QString normalized = normalizeSubPath(subPath);
+    qInfo() << "CustomShortcutStore: resetting custom shortcut DConfig:" << normalized;
+
+    QStringList resetKeys = configObject->keyList();
+    resetKeys.append(CustomShortcutKeys);
+    resetKeys.removeDuplicates();
+
+    const QSignalBlocker blocker(configObject);
+    for (const QString &key : resetKeys)
+        configObject->reset(key);
+}
+
+QString CustomShortcutStore::normalizeSubPath(const QString &raw)
+{
+    const QString trimmed = raw.trimmed();
+    return trimmed.startsWith(QLatin1Char('/')) ? trimmed.mid(1) : trimmed;
+}
+
+QStringList CustomShortcutStore::subPaths() const
+{
+    QSettings settings(m_iniPath, QSettings::IniFormat);
+    settings.beginGroup("Config");
+    const QVariant subPathsVar = settings.value("SubPaths");
+    QStringList paths;
+    if (subPathsVar.typeId() == QMetaType::QStringList) {
+        paths = subPathsVar.toStringList();
+    } else {
+        paths = subPathsVar.toString().split(",", Qt::SkipEmptyParts);
+    }
+    settings.endGroup();
+
+    for (QString &subPath : paths)
+        subPath = normalizeSubPath(subPath);
+    paths.removeAll(QString());
+    paths.removeDuplicates();
+    paths.sort();
+    return paths;
+}
+
+bool CustomShortcutStore::writeSubPaths(const QStringList &subPaths) const
+{
+    const QFileInfo info(m_iniPath);
+    QDir dir(info.absolutePath());
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        qWarning() << "CustomShortcutStore: failed to create custom shortcut ini dir:" << info.absolutePath();
+        return false;
+    }
+
+    QStringList normalized;
+    normalized.reserve(subPaths.size());
+    for (const QString &subPath : subPaths) {
+        const QString value = normalizeSubPath(subPath);
+        if (!value.isEmpty() && !normalized.contains(value))
+            normalized.append(value);
+    }
+    normalized.sort();
+
+    QSettings settings(m_iniPath, QSettings::IniFormat);
+    settings.beginGroup("Config");
+    settings.setValue("SubPaths", normalized);
+    settings.endGroup();
+    settings.sync();
+
+    if (settings.status() != QSettings::NoError) {
+        qWarning() << "CustomShortcutStore: failed to write custom shortcut ini:" << m_iniPath;
+        return false;
+    }
+    return true;
+}

--- a/src/plugin-qt/shortcut/src/config/customshortcutstore.h
+++ b/src/plugin-qt/shortcut/src/config/customshortcutstore.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "core/shortcutconfig.h"
+
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+#include <DConfig>
+
+DCORE_USE_NAMESPACE
+
+class QObject;
+
+class CustomShortcutStore
+{
+public:
+    CustomShortcutStore();
+
+    QSet<QString> discoverSubPaths() const;
+    DConfig *createConfig(const QString &subPath, QObject *parent) const;
+
+    bool save(const KeyConfig &config, DConfig *configObject) const;
+    bool updateCustomShortcutFields(const KeyConfig &config, DConfig *configObject) const;
+    bool removeSubPath(const QString &subPath) const;
+    void reset(DConfig *configObject, const QString &subPath) const;
+
+    static QString normalizeSubPath(const QString &raw);
+
+private:
+    QStringList subPaths() const;
+    bool writeSubPaths(const QStringList &subPaths) const;
+
+    QString m_iniPath;
+};

--- a/src/plugin-qt/shortcut/src/core/gesturemanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/gesturemanager.cpp
@@ -79,7 +79,9 @@ QList<GestureInfo> GestureManager::ListAllGestures()
         info.direction = config.direction;
         info.triggerType = config.triggerType;
         info.triggerValue = config.triggerValue;
+        info.isCustom = (config.category == CategoryKey::Custom);
         info.localLanguageName = m_translationManager->translate(config.appId, config.displayName);
+        info.localLanguageCategory = m_translationManager->translate(config.appId, config.category);
         list.append(info);
     }
     return list;

--- a/src/plugin-qt/shortcut/src/core/gesturemanager.h
+++ b/src/plugin-qt/shortcut/src/core/gesturemanager.h
@@ -21,13 +21,15 @@ class TranslationManager;
 struct GestureInfo {
     QString id;
     QString displayName;
-    int category;
+    QString category;
     int gestureType;
     int fingerCount;
     int direction;
     int triggerType;
     QStringList triggerValue;
     QString localLanguageName;
+    QString localLanguageCategory;
+    bool isCustom = false;
 };
 Q_DECLARE_METATYPE(GestureInfo)
 
@@ -84,14 +86,14 @@ Q_DECLARE_METATYPE(QList<GestureInfo>)
 
 inline QDBusArgument &operator<<(QDBusArgument &argument, const GestureInfo &info) {
     argument.beginStructure();
-    argument << info.id << info.displayName << info.category << info.gestureType << info.fingerCount << info.direction << info.triggerType << info.triggerValue << info.localLanguageName;
+    argument << info.id << info.displayName << info.category << info.gestureType << info.fingerCount << info.direction << info.triggerType << info.triggerValue << info.localLanguageName << info.localLanguageCategory << info.isCustom;
     argument.endStructure();
     return argument;
 }
 
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, GestureInfo &info) {
     argument.beginStructure();
-    argument >> info.id >> info.displayName >> info.category >> info.gestureType >> info.fingerCount >> info.direction >> info.triggerType >> info.triggerValue >> info.localLanguageName;
+    argument >> info.id >> info.displayName >> info.category >> info.gestureType >> info.fingerCount >> info.direction >> info.triggerType >> info.triggerValue >> info.localLanguageName >> info.localLanguageCategory >> info.isCustom;
     argument.endStructure();
     return argument;
 }

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -13,6 +13,8 @@
 
 #include <QDebug>
 #include <QDBusConnection>
+#include <QHash>
+#include <algorithm>
 
 // Normalize a hotkey from XKB form ("<Control><Alt>T") to Qt PortableText
 // ("Ctrl+Alt+T"). Inputs already in Qt form pass through unchanged.
@@ -51,6 +53,11 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
 
     qDBusRegisterMetaType<ShortcutInfo>();
     qDBusRegisterMetaType<QList<ShortcutInfo>>();
+
+    qRegisterMetaType<CategoryInfo>("CategoryInfo");
+    qRegisterMetaType<QList<CategoryInfo>>("QList<CategoryInfo>");
+    qDBusRegisterMetaType<CategoryInfo>();
+    qDBusRegisterMetaType<QList<CategoryInfo>>();
 
     // Connect signals from key handler
     connect(m_keyHandler, &AbstractKeyHandler::keyActivated, this, &KeybindingManager::onKeyActivated);
@@ -124,7 +131,7 @@ QList<ShortcutInfo> KeybindingManager::ListShortcutsByApp(const QString &appId)
     return list;
 }
 
-QList<ShortcutInfo> KeybindingManager::ListShortcutsByCategory(int category)
+QList<ShortcutInfo> KeybindingManager::ListShortcutsByCategory(const QString &category)
 {
     QList<ShortcutInfo> list;
     QList<KeyConfig> configs = m_keyConfigsMap.values();
@@ -135,6 +142,53 @@ QList<ShortcutInfo> KeybindingManager::ListShortcutsByCategory(int category)
     }
 
     return list;
+}
+
+// Fixed display order for framework-reserved categories. The service owns
+// these, so it is entitled to define their canonical sequence. App-defined
+// categories slot in after Workspace and before Custom (which is always last).
+static const QHash<QString, int> &reservedCategoryOrder()
+{
+    static const QHash<QString, int> order{
+        {QStringLiteral("System"),     0},
+        {QStringLiteral("Window"),     1},
+        {QStringLiteral("Workspace"),  2},
+        {QStringLiteral("Custom"),     99},   // always last
+    };
+    return order;
+}
+
+QList<CategoryInfo> KeybindingManager::ListCategories()
+{
+    // Collect distinct categories from the user-visible (modifiable, with
+    // hotkeys) configs — mirrors ListAllShortcuts' filter so the category
+    // set matches what the control center actually renders.
+    QHash<QString, CategoryInfo> seen;
+    int appOrder = 10;  // app-defined categories land after Workspace(2), before Custom(99)
+    for (const auto &config : m_keyConfigsMap) {
+        if (!config.modifiable || config.category.isEmpty())
+            continue;
+        if (!seen.contains(config.category)) {
+            CategoryInfo ci;
+            ci.key = config.category;
+            ci.displayName = m_translationManager->translate(config.appId, config.category);
+            ci.isCustom = (config.category == CategoryKey::Custom);
+            const auto &reserved = reservedCategoryOrder();
+            if (reserved.contains(config.category)) {
+                ci.order = reserved.value(config.category);
+            } else {
+                ci.order = appOrder++;   // first-seen order for app-defined
+            }
+            seen.insert(config.category, ci);
+        }
+    }
+
+    QList<CategoryInfo> result = seen.values();
+    std::sort(result.begin(), result.end(),
+              [](const CategoryInfo &a, const CategoryInfo &b) {
+        return a.order < b.order;
+    });
+    return result;
 }
 
 ShortcutInfo KeybindingManager::GetShortcut(const QString &id)
@@ -652,6 +706,8 @@ ShortcutInfo KeybindingManager::toShortcutInfo(const KeyConfig &config)
         info.hotkeys.append(QKeySequenceConverter::qKeySequenceToXkb(hk));
     }
     info.localLanguageName = m_translationManager->translate(config.appId, config.displayName);
+    info.isCustom = (config.category == CategoryKey::Custom);
+    info.localLanguageCategory = m_translationManager->translate(config.appId, config.category);
     return info;
 }
 

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -14,6 +14,7 @@
 #include <QDebug>
 #include <QDBusConnection>
 #include <QHash>
+#include <QUuid>
 #include <algorithm>
 
 // Normalize a hotkey from XKB form ("<Control><Alt>T") to Qt PortableText
@@ -34,6 +35,48 @@ static QStringList normalizeHotkeys(const QStringList &hotkeys)
     for (const QString &h : hotkeys)
         out.append(normalizeHotkey(h));
     return out;
+}
+
+constexpr int MaxCustomShortcutCount = 200;
+constexpr int MaxCustomShortcutNameLength = 128;
+constexpr int MaxCustomShortcutCommandLength = 4096;
+constexpr int MaxCustomShortcutHotkeyLength = 256;
+
+static bool containsControlCharacter(const QString &text)
+{
+    for (const QChar ch : text) {
+        const QChar::Category category = ch.category();
+        if (category == QChar::Other_Control
+            || category == QChar::Other_Format
+            || category == QChar::Other_Surrogate
+            || category == QChar::Other_PrivateUse
+            || category == QChar::Other_NotAssigned) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool isValidCustomShortcutName(const QString &name)
+{
+    return !name.isEmpty()
+            && name.size() <= MaxCustomShortcutNameLength
+            && !containsControlCharacter(name);
+}
+
+static bool isValidCustomShortcutCommand(const QString &command)
+{
+    return !command.isEmpty()
+            && command.size() <= MaxCustomShortcutCommandLength
+            && !containsControlCharacter(command);
+}
+
+static bool isValidCustomShortcutHotkey(const QString &hotkey, bool allowEmpty)
+{
+    if (hotkey.isEmpty())
+        return allowEmpty;
+    return hotkey.size() <= MaxCustomShortcutHotkeyLength
+            && !containsControlCharacter(hotkey);
 }
 
 KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *executor,
@@ -67,7 +110,10 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
     
     connect(m_loader, &ConfigLoader::keyConfigChanged, this, &KeybindingManager::onKeyConfigChanged);
     connect(m_loader, &ConfigLoader::keyConfigAdded, this, [this](const KeyConfig &newConfig){
-        if (registerShortcut(newConfig)) {
+        if (newConfig.isDisplayOnly()) {
+            m_keyConfigsMap[newConfig.getId()] = newConfig;
+            emit ShortcutChanged(newConfig.getId(), toShortcutInfo(newConfig));
+        } else if (registerShortcut(newConfig)) {
             m_keyConfigsMap[newConfig.getId()] = newConfig;
             m_keyHandler->commit();
         }
@@ -88,7 +134,9 @@ void KeybindingManager::registerAllShortcuts()
     
     // Register existing configs
     for (const KeyConfig &config : m_loader->keys()) {
-        if (registerShortcut(config)) {
+        if (config.isDisplayOnly()) {
+            m_keyConfigsMap[config.getId()] = config;
+        } else if (registerShortcut(config)) {
             m_keyConfigsMap[config.getId()] = config;
         }
     }
@@ -108,9 +156,9 @@ QList<ShortcutInfo> KeybindingManager::ListAllShortcuts()
     for (const auto &config : m_keyConfigsMap) {
         // Only expose modifiable shortcuts — control center filters out
         // non-modifiable entries to avoid showing read-only items.
-        // Skip shortcuts with no hotkeys (e.g. after ReplaceHotkey stole
-        // the last binding but before the next reload prunes them).
-        if (!config.modifiable || config.hotkeys.isEmpty()) {
+        // Empty hotkeys are still exposed so the control center can show
+        // the existing row as "None" after another shortcut takes its binding.
+        if (!config.modifiable) {
             continue;
         }
         list.append(toShortcutInfo(config));
@@ -199,6 +247,17 @@ ShortcutInfo KeybindingManager::GetShortcut(const QString &id)
     }
 
     return ShortcutInfo();
+}
+
+QString KeybindingManager::GetShortcutCommand(const QString &id)
+{
+    const KeyConfig config = m_keyConfigsMap.value(id);
+    if (config.category == QLatin1String(CategoryKey::Custom)
+        && config.triggerType == static_cast<int>(TriggerType::Command)
+        && !config.triggerValue.isEmpty()) {
+        return config.triggerValue.first();
+    }
+    return QString();
 }
 
 ShortcutInfo KeybindingManager::LookupConflictShortcut(const QString &hotkey)
@@ -315,6 +374,317 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
     return true;
 }
 
+QString KeybindingManager::AddCustomShortcut(const QString &name, const QString &command, const QString &hotkey)
+{
+    const QString displayName = name.trimmed();
+    const QString commandText = command.trimmed();
+    const QString normalized = normalizeHotkey(hotkey);
+
+    if (runtimeCustomShortcutCount() >= MaxCustomShortcutCount) {
+        qWarning() << "AddCustomShortcut: custom shortcut count limit reached";
+        return QString();
+    }
+
+    if (!isValidCustomShortcutName(displayName)
+        || !isValidCustomShortcutCommand(commandText)
+        || !isValidCustomShortcutHotkey(normalized, false)) {
+        qWarning() << "AddCustomShortcut: invalid input";
+        return QString();
+    }
+
+    KeyConfig config;
+    config.appId = QStringLiteral("org.deepin.dde.keybinding");
+    config.subPath = createCustomShortcutId();
+    config.displayName = displayName;
+    config.category = QString::fromLatin1(CategoryKey::Custom);
+    config.enabled = true;
+    config.modifiable = true;
+    config.triggerType = static_cast<int>(TriggerType::Command);
+    config.triggerValue = QStringList{commandText};
+    config.hotkeys = QStringList{normalized};
+    config.keyEventFlags = KeyEventFlag::Release;
+
+    ShortcutInfo conflictInfo = LookupConflictShortcut(normalized);
+    const bool hasConflict = !conflictInfo.id.isEmpty();
+    KeyConfig conflictConfig;
+    QStringList oldConflictHotkeys;
+    if (hasConflict) {
+        conflictConfig = m_keyConfigsMap.value(conflictInfo.id);
+        if (!canPersistShortcutHotkeys(conflictConfig)) {
+            qWarning() << "AddCustomShortcut: conflict shortcut can not be replaced:"
+                       << conflictInfo.id
+                       << "modifiable:" << conflictConfig.modifiable
+                       << "has writable config:" << m_loader->canUpdateValue(conflictInfo.id);
+            return QString();
+        }
+        oldConflictHotkeys = conflictConfig.hotkeys;
+        conflictConfig.hotkeys.removeOne(normalized);
+        unregisterShortcut(conflictInfo.id);
+    }
+
+    const QStringList excludedIds = hasConflict ? QStringList{conflictInfo.id} : QStringList();
+    if (!registerShortcut(config, excludedIds)) {
+        qWarning() << "AddCustomShortcut: failed to register" << config.getId();
+        if (hasConflict) {
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+            m_keyHandler->commitSync();
+        }
+        return QString();
+    }
+
+    bool conflictRegistered = true;
+    if (hasConflict && !conflictConfig.hotkeys.isEmpty())
+        conflictRegistered = registerShortcut(conflictConfig, excludedIds);
+
+    if (!conflictRegistered) {
+        qWarning() << "AddCustomShortcut: failed to re-register conflict shortcut" << conflictInfo.id;
+        unregisterShortcut(config.getId());
+        conflictConfig.hotkeys = oldConflictHotkeys;
+        registerShortcut(conflictConfig, excludedIds);
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (!m_keyHandler->commitSync()) {
+        qWarning() << "AddCustomShortcut: commit failed, rolling back" << config.getId();
+        unregisterShortcut(config.getId());
+        if (hasConflict) {
+            unregisterShortcut(conflictInfo.id);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (hasConflict) {
+        m_keyConfigsMap[conflictInfo.id] = conflictConfig;
+    }
+
+    if (!m_loader->saveCustomShortcut(config)) {
+        qWarning() << "AddCustomShortcut: failed to persist custom shortcut, rolling back" << config.getId();
+        unregisterShortcut(config.getId());
+        if (hasConflict) {
+            unregisterShortcut(conflictInfo.id);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+            m_keyConfigsMap[conflictInfo.id] = conflictConfig;
+            emit ShortcutChanged(conflictInfo.id, toShortcutInfo(conflictConfig));
+        }
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (hasConflict && !m_loader->updateValue(conflictInfo.id, "hotkeys", conflictConfig.hotkeys)) {
+        qWarning() << "AddCustomShortcut: failed to persist conflict shortcut, rolling back" << conflictInfo.id;
+        m_loader->removeCustomShortcut(config.getId());
+        unregisterShortcut(config.getId());
+        unregisterShortcut(conflictInfo.id);
+        conflictConfig.hotkeys = oldConflictHotkeys;
+        registerShortcut(conflictConfig, excludedIds);
+        m_keyConfigsMap[conflictInfo.id] = conflictConfig;
+        emit ShortcutChanged(conflictInfo.id, toShortcutInfo(conflictConfig));
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (hasConflict) {
+        emit ShortcutChanged(conflictInfo.id, toShortcutInfo(conflictConfig));
+    }
+    m_keyConfigsMap[config.getId()] = config;
+    emit ShortcutChanged(config.getId(), toShortcutInfo(config));
+    return config.getId();
+}
+
+bool KeybindingManager::ModifyCustomShortcut(const QString &id, const QString &name,
+                                             const QString &command, const QString &hotkey)
+{
+    if (!m_keyConfigsMap.contains(id)) {
+        return false;
+    }
+
+    KeyConfig oldConfig = m_keyConfigsMap[id];
+    if (!isRuntimeCustomShortcut(oldConfig)) {
+        qWarning() << "ModifyCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
+        return false;
+    }
+
+    const QString displayName = name.trimmed();
+    const QString commandText = command.trimmed();
+    const QString normalized = normalizeHotkey(hotkey);
+    if (!isValidCustomShortcutName(displayName)
+        || !isValidCustomShortcutCommand(commandText)
+        || !isValidCustomShortcutHotkey(normalized, true)) {
+        qWarning() << "ModifyCustomShortcut: invalid input" << id;
+        return false;
+    }
+
+    KeyConfig newConfig = oldConfig;
+    newConfig.displayName = displayName;
+    newConfig.triggerValue = QStringList{commandText};
+    newConfig.hotkeys = normalized.isEmpty() ? QStringList() : QStringList{normalized};
+    newConfig.enabled = true;
+    newConfig.modifiable = true;
+    newConfig.category = QString::fromLatin1(CategoryKey::Custom);
+    newConfig.triggerType = static_cast<int>(TriggerType::Command);
+
+    const bool hotkeysChanged = oldConfig.hotkeys != newConfig.hotkeys;
+    if (!hotkeysChanged) {
+        if (oldConfig == newConfig)
+            return true;
+
+        if (!m_loader->updateCustomShortcut(newConfig)) {
+            qWarning() << "ModifyCustomShortcut: failed to persist custom shortcut:" << id;
+            return false;
+        }
+
+        m_keyConfigsMap[id] = newConfig;
+        emit ShortcutChanged(id, toShortcutInfo(newConfig));
+        return true;
+    }
+
+    ShortcutInfo conflictInfo = LookupConflictShortcut(normalized);
+    const bool hasConflict = !conflictInfo.id.isEmpty() && conflictInfo.id != id;
+    KeyConfig conflictConfig;
+    QStringList oldConflictHotkeys;
+    if (hasConflict) {
+        conflictConfig = m_keyConfigsMap.value(conflictInfo.id);
+        if (!canPersistShortcutHotkeys(conflictConfig)) {
+            qWarning() << "ModifyCustomShortcut: conflict shortcut can not be replaced:"
+                       << conflictInfo.id
+                       << "modifiable:" << conflictConfig.modifiable
+                       << "has writable config:" << m_loader->canUpdateValue(conflictInfo.id);
+            return false;
+        }
+        oldConflictHotkeys = conflictConfig.hotkeys;
+        conflictConfig.hotkeys.removeOne(normalized);
+        unregisterShortcut(conflictInfo.id);
+    }
+
+    unregisterShortcut(id);
+    const QStringList excludedIds = hasConflict ? QStringList{id, conflictInfo.id} : QStringList{id};
+    bool newRegistered = true;
+    if (!newConfig.hotkeys.isEmpty())
+        newRegistered = registerShortcut(newConfig, excludedIds);
+    if (!newRegistered) {
+        qWarning() << "ModifyCustomShortcut: failed to register" << id;
+        if (hasConflict) {
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    bool conflictRegistered = true;
+    if (hasConflict && !conflictConfig.hotkeys.isEmpty())
+        conflictRegistered = registerShortcut(conflictConfig, QStringList{id, conflictInfo.id});
+
+    if (!conflictRegistered) {
+        qWarning() << "ModifyCustomShortcut: failed to re-register conflict shortcut" << conflictInfo.id;
+        unregisterShortcut(id);
+        if (hasConflict) {
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        if (registerShortcut(oldConfig, QStringList{id}))
+            m_keyHandler->commitSync();
+        return false;
+    }
+
+    if (!m_keyHandler->commitSync()) {
+        qWarning() << "ModifyCustomShortcut: commit failed, rolling back" << id;
+        unregisterShortcut(id);
+        if (hasConflict) {
+            unregisterShortcut(conflictInfo.id);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    if (hasConflict) {
+        m_keyConfigsMap[conflictInfo.id] = conflictConfig;
+    }
+
+    if (!m_loader->updateCustomShortcut(newConfig)) {
+        qWarning() << "ModifyCustomShortcut: failed to persist custom shortcut, rolling back" << id;
+        m_loader->updateCustomShortcut(oldConfig);
+        unregisterShortcut(id);
+        if (hasConflict) {
+            unregisterShortcut(conflictInfo.id);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+            m_keyConfigsMap[conflictInfo.id] = conflictConfig;
+            emit ShortcutChanged(conflictInfo.id, toShortcutInfo(conflictConfig));
+        }
+        if (registerShortcut(oldConfig, QStringList{id}))
+            m_keyHandler->commitSync();
+        return false;
+    }
+
+    if (hasConflict && !m_loader->updateValue(conflictInfo.id, "hotkeys", conflictConfig.hotkeys)) {
+        qWarning() << "ModifyCustomShortcut: failed to persist conflict shortcut, rolling back" << conflictInfo.id;
+        m_loader->updateCustomShortcut(oldConfig);
+        unregisterShortcut(id);
+        unregisterShortcut(conflictInfo.id);
+        conflictConfig.hotkeys = oldConflictHotkeys;
+        registerShortcut(conflictConfig, excludedIds);
+        m_keyConfigsMap[conflictInfo.id] = conflictConfig;
+        if (registerShortcut(oldConfig, QStringList{id}))
+            m_keyHandler->commitSync();
+        emit ShortcutChanged(conflictInfo.id, toShortcutInfo(conflictConfig));
+        return false;
+    }
+
+    if (hasConflict) {
+        emit ShortcutChanged(conflictInfo.id, toShortcutInfo(conflictConfig));
+    }
+    m_keyConfigsMap[id] = newConfig;
+    emit ShortcutChanged(id, toShortcutInfo(newConfig));
+    return true;
+}
+
+bool KeybindingManager::DeleteCustomShortcut(const QString &id)
+{
+    if (!m_keyConfigsMap.contains(id)) {
+        return false;
+    }
+
+    KeyConfig oldConfig = m_keyConfigsMap[id];
+    if (!isRuntimeCustomShortcut(oldConfig)) {
+        qWarning() << "DeleteCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
+        return false;
+    }
+
+    unregisterShortcut(id);
+    if (!m_keyHandler->commitSync()) {
+        qWarning() << "DeleteCustomShortcut: commit failed, restoring" << id;
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    if (!m_loader->removeCustomShortcut(id)) {
+        qWarning() << "DeleteCustomShortcut: failed to remove persisted custom shortcut, restoring" << id;
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    m_keyConfigsMap.remove(id);
+    emit ShortcutRemoved(id);
+    return true;
+}
+
 bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
 {
     if (id1 == id2)
@@ -329,6 +699,12 @@ bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
     if (!config1.enabled || !config1.modifiable || !config2.enabled || !config2.modifiable) {
         qWarning() << "SwapHotkeys: both shortcuts must be enabled and modifiable:"
                     << id1 << id2;
+        return false;
+    }
+    if (!canPersistShortcutHotkeys(config1) || !canPersistShortcutHotkeys(config2)) {
+        qWarning() << "SwapHotkeys: both shortcuts must have writable configs:"
+                    << id1 << m_loader->canUpdateValue(id1)
+                    << id2 << m_loader->canUpdateValue(id2);
         return false;
     }
 
@@ -415,6 +791,12 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
         qWarning() << "ReplaceHotkey: conflict shortcut not modifiable or enabled:" << conflictId;
         return false;
     }
+    if (!canPersistShortcutHotkeys(targetConfig) || !canPersistShortcutHotkeys(conflictConfig)) {
+        qWarning() << "ReplaceHotkey: target and conflict shortcuts must have writable configs:"
+                    << targetId << m_loader->canUpdateValue(targetId)
+                    << conflictId << m_loader->canUpdateValue(conflictId);
+        return false;
+    }
 
     const QString normalized = normalizeHotkey(newHotkey);
 
@@ -465,14 +847,7 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
     m_loader->updateValue(targetId, "hotkeys", targetConfig.hotkeys);
     m_loader->updateValue(conflictId, "hotkeys", conflictConfig.hotkeys);
     emit ShortcutChanged(targetId, toShortcutInfo(targetConfig));
-    if (conflictConfig.hotkeys.isEmpty()) {
-        // Last hotkey was stolen.
-        // The shortcut stays in dconfig with empty hotkeys; on next load
-        // registerShortcut will skip it (isValid requires non-empty hotkeys).
-        emit ShortcutRemoved(conflictId);
-    } else {
-        emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
-    }
+    emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
 
     return true;
 }
@@ -530,6 +905,8 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &config)
         if (!config.enabled) {
             // new one, but disabled, skip
             return;
+        } else if (config.isDisplayOnly()) {
+            m_keyConfigsMap[config.getId()] = config;
         } else {
             // new one, enable
             if (registerShortcut(config)) {
@@ -539,6 +916,9 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &config)
         }
     } else { // exist
         KeyConfig &old = m_keyConfigsMap[config.getId()];
+        if (old == config)
+            return;
+
         if (!config.enabled) {
             // enable->disable
             m_keyHandler->unregisterKey(config.getId());
@@ -548,7 +928,9 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &config)
             // update
             m_keyHandler->unregisterKey(config.getId());
             m_keyConfigsMap.remove(config.getId());
-            if (registerShortcut(config)) {
+            if (config.isDisplayOnly()) {
+                m_keyConfigsMap[config.getId()] = config;
+            } else if (registerShortcut(config)) {
                 m_keyConfigsMap[config.getId()] = config;
             }
             m_keyHandler->commit();
@@ -591,18 +973,18 @@ void KeybindingManager::onKeyActivated(const QString &shortcutId)
     }
 }
 
-bool KeybindingManager::registerShortcut(const KeyConfig &config)
+bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringList &excludeIds)
 {
-    if (!config.isValid()) {
-        qWarning() << "Shortcut is disabled or invalid, skipping registration:"
-                    << "Enabled:" << config.enabled
-                    << "AppId:" << config.appId
-                    << "DisplayName:" << config.displayName
-                    << "hotkeys:" << config.hotkeys;
+    if (!config.canRegister()) {
+        qWarning() << "Shortcut can not be registered, skipping:"
+                   << "Enabled:" << config.enabled
+                   << "AppId:" << config.appId
+                   << "DisplayName:" << config.displayName
+                   << "hotkeys:" << config.hotkeys;
         return false;
     }
 
-    if (m_keyConfigsMap.contains(config.getId())) {
+    if (m_keyConfigsMap.contains(config.getId()) && !excludeIds.contains(config.getId())) {
         qWarning() << "Shortcut conflict detected during init: has same appId and displayName"
                     << "hotkeys:" << config.hotkeys
                     << "Conflicts with:" << m_keyConfigsMap[config.getId()].hotkeys
@@ -629,7 +1011,7 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config)
         // Check for conflicts before registering
         for (const QString &hotkey : normalHotkeys) {
             auto shortcutInfo = LookupConflictShortcut(hotkey);
-            if (!shortcutInfo.id.isEmpty()) {
+            if (!shortcutInfo.id.isEmpty() && !excludeIds.contains(shortcutInfo.id)) {
                 qWarning() << "Shortcut conflict detected during init:"
                             << "Config appId:" << config.appId
                             << "Config displayName:" << config.displayName
@@ -662,34 +1044,42 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config)
     return registered;
 }
 
-QString KeybindingManager::checkConflictForConfig(const KeyConfig &config, const QString &excludeId)
+void KeybindingManager::unregisterShortcut(const QString &id)
 {
-    QString currentId = config.getId();
-    
-    // Check each hotkey in the config
-    for (const QString &hotkey : config.hotkeys) {
-        // Search through all registered shortcuts
-        for (const KeyConfig &existingConfig : m_keyConfigsMap) {
-            QString existingId = existingConfig.getId();
-            
-            // Skip if this is the config we're excluding (self-check)
-            if (!excludeId.isEmpty() && existingId == excludeId) {
-                continue;
-            }
-            
-            // Skip if not enabled
-            if (!existingConfig.enabled) {
-                continue;
-            }
-            
-            // Check if hotkey conflicts
-            if (existingConfig.hotkeys.contains(hotkey)) {
-                return existingId; // Return the conflicting shortcut ID
-            }
-        }
+    m_keyHandler->unregisterKey(id);
+    m_specialKeyHandler->unregisterKey(id);
+}
+
+bool KeybindingManager::isRuntimeCustomShortcut(const KeyConfig &config) const
+{
+    return config.category == QLatin1String(CategoryKey::Custom)
+            && config.modifiable
+            && config.subPath.startsWith(QStringLiteral("org.deepin.dde.keybinding.shortcut.custom."));
+}
+
+bool KeybindingManager::canPersistShortcutHotkeys(const KeyConfig &config) const
+{
+    return config.modifiable && m_loader->canUpdateValue(config.getId());
+}
+
+int KeybindingManager::runtimeCustomShortcutCount() const
+{
+    int count = 0;
+    for (const KeyConfig &config : m_keyConfigsMap) {
+        if (isRuntimeCustomShortcut(config))
+            ++count;
     }
-    
-    return QString(); // No conflict
+    return count;
+}
+
+QString KeybindingManager::createCustomShortcutId() const
+{
+    QString id;
+    do {
+        id = QStringLiteral("org.deepin.dde.keybinding.shortcut.custom.")
+                + QUuid::createUuid().toString(QUuid::WithoutBraces);
+    } while (m_keyConfigsMap.contains(id));
+    return id;
 }
 
 ShortcutInfo KeybindingManager::toShortcutInfo(const KeyConfig &config)

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -22,11 +22,23 @@ class TranslationManager;
 struct ShortcutInfo {
     QString id;
     QString displayName;
-    int category;
+    QString category;
     QStringList hotkeys;
     QString localLanguageName;
+    QString localLanguageCategory;
+    bool isCustom = false;
 };
 Q_DECLARE_METATYPE(ShortcutInfo)
+
+// Category metadata for the ListCategories() interface.
+struct CategoryInfo {
+    QString key;                    // Logical category key
+    QString displayName;            // Resolved display text
+    int order = 0;                  // Display order (lower = earlier)
+    bool isCustom = false;          // True for the user-editable category
+};
+Q_DECLARE_METATYPE(CategoryInfo)
+Q_DECLARE_METATYPE(QList<CategoryInfo>)
 
 class KeybindingManager : public QObject, protected QDBusContext
 {
@@ -59,7 +71,9 @@ public slots:
     // DBus Methods
     Q_SCRIPTABLE QList<ShortcutInfo> ListAllShortcuts();
     Q_SCRIPTABLE QList<ShortcutInfo> ListShortcutsByApp(const QString &appId);
-    Q_SCRIPTABLE QList<ShortcutInfo> ListShortcutsByCategory(int category);
+    Q_SCRIPTABLE QList<ShortcutInfo> ListShortcutsByCategory(const QString &category);
+
+    Q_SCRIPTABLE QList<CategoryInfo> ListCategories();
 
     Q_SCRIPTABLE ShortcutInfo GetShortcut(const QString &id);
     Q_SCRIPTABLE ShortcutInfo LookupConflictShortcut(const QString &hotkey);
@@ -119,14 +133,30 @@ Q_DECLARE_METATYPE(QList<ShortcutInfo>)
 
 inline QDBusArgument &operator<<(QDBusArgument &argument, const ShortcutInfo &info) {
     argument.beginStructure();
-    argument << info.id << info.displayName << info.category << info.hotkeys << info.localLanguageName;
+    argument << info.id << info.displayName << info.category << info.hotkeys
+             << info.localLanguageName << info.localLanguageCategory << info.isCustom;
     argument.endStructure();
     return argument;
 }
 
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, ShortcutInfo &info) {
     argument.beginStructure();
-    argument >> info.id >> info.displayName >> info.category >> info.hotkeys >> info.localLanguageName;
+    argument >> info.id >> info.displayName >> info.category >> info.hotkeys
+             >> info.localLanguageName >> info.localLanguageCategory >> info.isCustom;
+    argument.endStructure();
+    return argument;
+}
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const CategoryInfo &info) {
+    argument.beginStructure();
+    argument << info.key << info.displayName << info.order << info.isCustom;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, CategoryInfo &info) {
+    argument.beginStructure();
+    argument >> info.key >> info.displayName >> info.order >> info.isCustom;
     argument.endStructure();
     return argument;
 }

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -76,11 +76,15 @@ public slots:
     Q_SCRIPTABLE QList<CategoryInfo> ListCategories();
 
     Q_SCRIPTABLE ShortcutInfo GetShortcut(const QString &id);
+    Q_SCRIPTABLE QString GetShortcutCommand(const QString &id);
     Q_SCRIPTABLE ShortcutInfo LookupConflictShortcut(const QString &hotkey);
     
     Q_SCRIPTABLE QList<ShortcutInfo> SearchShortcuts(const QString &keyword);
     Q_SCRIPTABLE bool ModifyHotkeys(const QString &id, const QStringList &newHotkeys);
     Q_SCRIPTABLE bool Disable(const QString &id);
+    Q_SCRIPTABLE QString AddCustomShortcut(const QString &name, const QString &command, const QString &hotkey);
+    Q_SCRIPTABLE bool ModifyCustomShortcut(const QString &id, const QString &name, const QString &command, const QString &hotkey);
+    Q_SCRIPTABLE bool DeleteCustomShortcut(const QString &id);
 
     // Atomically swap the hotkeys of two shortcuts in a single compositor commit.
     Q_SCRIPTABLE bool SwapHotkeys(const QString &id1, const QString &id2);
@@ -112,11 +116,15 @@ private slots:
     ShortcutInfo toShortcutInfo(const KeyConfig &config);
 
 private:
-    bool registerShortcut(const KeyConfig &config);
-    QString checkConflictForConfig(const KeyConfig &config, const QString &excludeId = QString());
+    bool registerShortcut(const KeyConfig &config, const QStringList &excludeIds = QStringList());
+    void unregisterShortcut(const QString &id);
     void rollbackRegistration(const QString &id1, const QString &id2,
                               KeyConfig &config1, KeyConfig &config2,
                               const QStringList &hotkeys1, const QStringList &hotkeys2);
+    bool isRuntimeCustomShortcut(const KeyConfig &config) const;
+    bool canPersistShortcutHotkeys(const KeyConfig &config) const;
+    int runtimeCustomShortcutCount() const;
+    QString createCustomShortcutId() const;
 
 
     ConfigLoader *m_loader;
@@ -160,5 +168,3 @@ inline const QDBusArgument &operator>>(const QDBusArgument &argument, CategoryIn
     argument.endStructure();
     return argument;
 }
-
-

--- a/src/plugin-qt/shortcut/src/core/shortcutconfig.h
+++ b/src/plugin-qt/shortcut/src/core/shortcutconfig.h
@@ -42,6 +42,17 @@ struct BaseConfig
     QStringList triggerValue;   // Command args, AppID, or Action Enum Value (as string list)
 
     QString getId() const { return subPath; }
+    bool operator==(const BaseConfig &other) const {
+        return appId == other.appId
+                && subPath == other.subPath
+                && displayName == other.displayName
+                && category == other.category
+                && enabled == other.enabled
+                && modifiable == other.modifiable
+                && triggerType == other.triggerType
+                && triggerValue == other.triggerValue;
+    }
+    bool operator!=(const BaseConfig &other) const { return !(*this == other); }
 };
 
 // Keyboard shortcut configuration
@@ -52,7 +63,17 @@ struct KeyConfig : public BaseConfig
 
     KeyConfig() : keyEventFlags(KeyEventFlag::Release) {} // Default to release
 
-    bool isValid() const { return enabled && !appId.isEmpty() && !displayName.isEmpty() && !hotkeys.isEmpty(); }
+    bool isValid() const { return enabled && !appId.isEmpty() && !displayName.isEmpty(); }
+    bool canRegister() const { return isValid() && !hotkeys.isEmpty(); }
+    // Valid enough to display (has identity) but carries no key binding — shown
+    // as "None" after another shortcut takes its binding.
+    bool isDisplayOnly() const { return enabled && modifiable && !appId.isEmpty() && !displayName.isEmpty() && hotkeys.isEmpty(); }
+    bool operator==(const KeyConfig &other) const {
+        return static_cast<const BaseConfig &>(*this) == static_cast<const BaseConfig &>(other)
+                && hotkeys == other.hotkeys
+                && keyEventFlags == other.keyEventFlags;
+    }
+    bool operator!=(const KeyConfig &other) const { return !(*this == other); }
 };
 
 enum class GestureType {
@@ -68,6 +89,13 @@ struct GestureConfig : public BaseConfig
     int direction;          // 0: None, 1: Down, 2: Left, 3: Up, 4: Right
 
     bool isValid() const { return enabled && !appId.isEmpty() && !displayName.isEmpty() && gestureType > 0 && fingerCount > 0; }
+    bool operator==(const GestureConfig &other) const {
+        return static_cast<const BaseConfig &>(*this) == static_cast<const BaseConfig &>(other)
+                && gestureType == other.gestureType
+                && fingerCount == other.fingerCount
+                && direction == other.direction;
+    }
+    bool operator!=(const GestureConfig &other) const { return !(*this == other); }
 };
 
 Q_DECLARE_METATYPE(KeyConfig)

--- a/src/plugin-qt/shortcut/src/core/shortcutconfig.h
+++ b/src/plugin-qt/shortcut/src/core/shortcutconfig.h
@@ -21,11 +21,13 @@ namespace KeyEventFlag {
     constexpr int Repeat = 0x4;  // Trigger on key repeat (auto-repeat)
 }
 
-enum Category {
-    System = 1,
-    App,
-    Custom
-};
+// Framework-reserved shortcut categories.
+namespace CategoryKey {
+    inline constexpr const char *System = "System";
+    inline constexpr const char *Window = "Window";
+    inline constexpr const char *Workspace = "Workspace";
+    inline constexpr const char *Custom = "Custom";
+}
 
 // Base configuration information
 struct BaseConfig
@@ -33,7 +35,7 @@ struct BaseConfig
     QString appId;              // Application ID
     QString subPath;            // DConfig subPath (e.g. [appId].shortcut.xxx)
     QString displayName;        // Localized name
-    int category;               // 1: System, 2: App, 3: Custom
+    QString category;           // Logical category key (e.g. "System", "Window", app-defined)
     bool enabled;
     bool modifiable;
     int triggerType;            // 1: Command, 2: App, 3: Action

--- a/src/plugin-qt/shortcut/tools/extract_shortcuts_i18n.py
+++ b/src/plugin-qt/shortcut/tools/extract_shortcuts_i18n.py
@@ -11,9 +11,11 @@ import sys
 def extract_translations(config_dir, output_file, app_id):
     """
     Scans the config_dir for org.deepin.shortcut.json / org.deepin.gesture.json
-    files and extracts the displayName field into a dummy C++ file for lupdate scanning.
+    files and extracts the displayName and category fields into a dummy C++ file
+    for lupdate scanning. Both fields use the same translation model: the app
+    that provides the config provides the translation via its per-appId QM.
     """
-    display_names = set()
+    translatable = set()
     target_files = {"org.deepin.shortcut.json", "org.deepin.gesture.json"}
 
     for root, dirs, files in os.walk(config_dir):
@@ -24,20 +26,23 @@ def extract_translations(config_dir, output_file, app_id):
                         data = json.load(f)
                         contents = data.get("contents", {})
 
-                        # Check if modifiable is true
+                        # Only extract from modifiable (user-visible) configs
                         modifiable = contents.get("modifiable", {}).get("value", False)
                         if not modifiable:
                             continue
 
-                        # Extract displayName only if modifiable is true
                         display_name = contents.get("displayName", {}).get("value")
                         if display_name:
-                            display_names.add(display_name)
+                            translatable.add(display_name)
+
+                        category = contents.get("category", {}).get("value")
+                        if category and isinstance(category, str):
+                            translatable.add(category)
                     except Exception as e:
                         print(f"Error parsing {file}: {e}", file=sys.stderr)
 
-    if not display_names:
-        print(f"Warning: No shortcut definitions found in {config_dir}", file=sys.stderr)
+    if not translatable:
+        print(f"Warning: No translatable strings found in {config_dir}", file=sys.stderr)
 
     with open(output_file, 'w') as f:
         f.write('// This is an automatically generated file for shortcut translation extraction.\n')
@@ -46,7 +51,7 @@ def extract_translations(config_dir, output_file, app_id):
         f.write('// Mark strings for translation using QT_TRANSLATE_NOOP\n')
         f.write('// The array is marked as unused to suppress compiler warnings\n')
         f.write('[[maybe_unused]] static const char* shortcut_names[] = {\n')
-        for name in sorted(display_names):
+        for name in sorted(translatable):
             f.write(f'    QT_TRANSLATE_NOOP("{app_id}", "{name}"),\n')
         f.write('};\n')
 

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_en.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_en.ts
@@ -11,5 +11,21 @@
         <source>Default terminal</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_CN.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_CN.ts
@@ -11,5 +11,21 @@
         <source>Default terminal</source>
         <translation>终端</translation>
     </message>
+    <message>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation>窗口</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>工作空间</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>自定义</translation>
+    </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary
- Add user-level DConfig persistence for runtime custom shortcuts.
- Update ModifyCustomShortcut to write existing custom shortcut fields through a dedicated update path.
- Remove unused conflict helper after real checks stayed on LookupConflictShortcut/registerShortcut.

## Test plan
- cmake --build dde-services/build --target plugin-dde-shortcut

## Dependency
Stacked on #93. This branch is based on yixinshark:fix/shortcut-dynamic-categories, so the PR diff may include #93 until that PR is merged. Please review the top commit: 213e06a feat(shortcut): add custom shortcut CRUD and display-only support.