### PR TITLE
feat(shortcut): add custom shortcut CRUD persistence

### DIFF
--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SHORTCUT_COMMON_SOURCES
     ${SHORTCUT_SRC_DIR}/core/actionexecutor.cpp
     ${SHORTCUT_SRC_DIR}/core/translationmanager.cpp
     ${SHORTCUT_SRC_DIR}/config/configloader.cpp
+    ${SHORTCUT_SRC_DIR}/config/customshortcutstore.cpp
     ${SHORTCUT_SRC_DIR}/backend/abstractkeyhandler.h
     ${SHORTCUT_SRC_DIR}/backend/abstractgesturehandler.h
     ${SHORTCUT_SRC_DIR}/backend/specialkeyhandler.cpp
@@ -112,6 +113,12 @@ foreach(SUBDIR_PATH ${SHORTCUT_CONFIG_SUBDIRS})
         FILES "${SUBDIR_PATH}/org.deepin.shortcut.json"
     )
 endforeach()
+
+# install base json config
+dtk_add_config_meta_files(
+    APPID "org.deepin.dde.keybinding"
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/configs/org.deepin.shortcut.json"
+)
 
 foreach(SUBDIR_PATH ${GESTURE_CONFIG_SUBDIRS})
     dtk_add_config_meta_files(

--- a/src/plugin-qt/shortcut/configs/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.shortcut.json
@@ -1,0 +1,86 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "appId": {
+            "value": "org.deepin.dde.keybinding",
+            "serial": 0,
+            "flags": [],
+            "name": "appId",
+            "name[zh_CN]": "提供快捷键应用Id",
+            "description": "provide shortcut app id",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "displayName": {
+            "value": "",
+            "serial": 0,
+            "flags": [],
+            "name": "displayName",
+            "name[zh_CN]": "",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "hotkeys": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "hotkeys",
+            "name[zh_CN]": "快捷键组合",
+            "description": "打开默认终端快捷键组合",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "triggerType": {
+            "value": 1,
+            "serial": 0,
+            "flags": [],
+            "name": "triggerType",
+            "name[zh_CN]": "快捷键触发动作类型",
+            "description": "二进制command类型",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "triggerValue": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "triggerValue",
+            "name[zh_CN]": "快捷键触发动作",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "category": {
+            "value": "Custom",
+            "serial": 1,
+            "flags": [],
+            "name": "category",
+            "name[zh_CN]": "快捷键类别（Custom）",
+            "description": "Custom shortcut category",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "enabled": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "enabled",
+            "name[zh_CN]": "使能",
+            "description": "是否启用快捷键",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "modifiable": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "modifiable",
+            "name[zh_CN]": "能否修改快捷键",
+            "description": "不能修改快捷键",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/src/plugin-qt/shortcut/src/config/configloader.cpp
+++ b/src/plugin-qt/shortcut/src/config/configloader.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "configloader.h"
-#include "core/shortcutconfig.h"
 
 #include <algorithm>
 
@@ -23,6 +22,12 @@ const QString CONFIG_NAME_GESTURE = "org.deepin.gesture";
 const QString CONFIG_SUBPATH_DIR = "/usr/share/deepin/org.deepin.dde.keybinding/";
 
 DCORE_USE_NAMESPACE
+
+static DConfig *createDConfig(const QString &name, const QString &subPath, QObject *parent)
+{
+    const QString normalized = CustomShortcutStore::normalizeSubPath(subPath);
+    return DConfig::create(APP_ID, name, QStringLiteral("/") + normalized, parent);
+}
 
 ConfigLoader::ConfigLoader(QObject *parent)
     : QObject(parent)
@@ -93,22 +98,36 @@ void ConfigLoader::resetConfig()
     }
 }
 
-void ConfigLoader::updateValue(const QString &id, const QString &key, const QVariant &value)
+bool ConfigLoader::updateValue(const QString &id, const QString &key, const QVariant &value)
 {
     if (!m_configs.contains(id)) {
         qWarning() << "ConfigLoader: config not found or can not be changed:" << id << key << value;
-        return;
+        return false;
     }
     
     m_configs[id]->setValue(key, value);
+    return true;
+}
+
+bool ConfigLoader::canUpdateValue(const QString &id) const
+{
+    return m_configs.contains(id);
 }
 
 QSet<QString> ConfigLoader::discoverSubPaths()
 {
-    // Accumulate all found subpaths
+    QSet<QString> foundSubPaths;
+    foundSubPaths.unite(scanIniSubPaths(CONFIG_SUBPATH_DIR));
+    foundSubPaths.unite(m_customStore.discoverSubPaths());
+
+    return foundSubPaths;
+}
+
+QSet<QString> ConfigLoader::scanIniSubPaths(const QString &dirPath)
+{
     QSet<QString> foundSubPaths;
 
-    QDir regDir(CONFIG_SUBPATH_DIR);
+    QDir regDir(dirPath);
     if (!regDir.exists()) {
         return foundSubPaths;
     }
@@ -119,7 +138,7 @@ QSet<QString> ConfigLoader::discoverSubPaths()
     static const QRegularExpression reContinuation(QStringLiteral("\\\\\\s*\\n"));
     QStringList iniFiles = regDir.entryList(QStringList() << "*.ini", QDir::Files | QDir::NoDotAndDotDot);
     for (const QString &iniFile : iniFiles) {
-        QString fullPath = QDir(CONFIG_SUBPATH_DIR).absoluteFilePath(iniFile);
+        QString fullPath = regDir.absoluteFilePath(iniFile);
         QFile file(fullPath);
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
             qWarning() << "ConfigLoader: Failed to open" << fullPath;
@@ -169,6 +188,122 @@ QSet<QString> ConfigLoader::discoverSubPaths()
     return foundSubPaths;
 }
 
+bool ConfigLoader::saveCustomShortcut(const KeyConfig &config)
+{
+    const QString subPath = CustomShortcutStore::normalizeSubPath(config.subPath);
+    DConfig *customDconfig = m_configs.value(subPath);
+    const bool existingDConfig = customDconfig;
+    if (!customDconfig) {
+        customDconfig = m_customStore.createConfig(subPath, this);
+        if (!customDconfig)
+            return false;
+        if (!customDconfig->isValid()) {
+            qWarning() << "ConfigLoader: failed to create custom shortcut DConfig:" << subPath;
+            delete customDconfig;
+            return false;
+        }
+    }
+
+    KeyConfig storedConfig = config;
+    storedConfig.subPath = subPath;
+    if (!m_customStore.save(storedConfig, customDconfig)) {
+        if (!existingDConfig) {
+            m_customStore.reset(customDconfig, subPath);
+            customDconfig->deleteLater();
+        }
+        return false;
+    }
+
+    auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                 [&](const KeyConfig &item) { return item.subPath == subPath; });
+    if (existing != m_keys.end())
+        *existing = storedConfig;
+    else
+        m_keys.append(storedConfig);
+
+    m_loadedSubPaths.insert(subPath);
+    if (!m_configs.contains(subPath)) {
+        connect(customDconfig, &DConfig::valueChanged, this, [this, subPath, customDconfig](const QString &key) {
+            if (!customDconfig->isValid() || !m_configs.contains(subPath)) {
+                qWarning() << "DConfig invalid or not found:" << subPath;
+                return;
+            }
+
+            KeyConfig updatedConfig = parseKeyConfig(customDconfig);
+            qDebug() << "DConfig value changed:" << subPath << key;
+            auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                         [&](const KeyConfig &item) { return item.subPath == subPath; });
+            if (existing != m_keys.end()) {
+                *existing = updatedConfig;
+            } else {
+                m_keys.append(updatedConfig);
+            }
+            emit keyConfigChanged(updatedConfig);
+        });
+        m_configs.insert(subPath, customDconfig);
+    }
+
+    return true;
+}
+
+bool ConfigLoader::updateCustomShortcut(const KeyConfig &config)
+{
+    const QString subPath = CustomShortcutStore::normalizeSubPath(config.subPath);
+    DConfig *customDconfig = m_configs.value(subPath);
+    if (!customDconfig) {
+        qWarning() << "ConfigLoader: custom shortcut config not found for update:" << subPath;
+        return false;
+    }
+
+    KeyConfig storedConfig = config;
+    storedConfig.subPath = subPath;
+    if (!m_customStore.updateCustomShortcutFields(storedConfig, customDconfig))
+        return false;
+
+    auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                 [&](const KeyConfig &item) { return item.subPath == subPath; });
+    if (existing != m_keys.end())
+        *existing = storedConfig;
+    else
+        m_keys.append(storedConfig);
+
+    m_loadedSubPaths.insert(subPath);
+    return true;
+}
+
+bool ConfigLoader::removeCustomShortcut(const QString &subPath)
+{
+    const QString normalized = CustomShortcutStore::normalizeSubPath(subPath);
+    if (normalized.isEmpty()) {
+        return false;
+    }
+
+    DConfig *config = m_configs.take(normalized);
+    if (!config || !config->isValid()) {
+        qWarning() << "ConfigLoader: custom shortcut config not found for removal:" << subPath;
+        if (config) config->deleteLater();
+        return false;
+    } else {
+        disconnect(config, nullptr, this, nullptr);
+    }
+
+    m_customStore.reset(config, normalized);
+    if (!m_customStore.removeSubPath(normalized)) {
+        qWarning() << "ConfigLoader: failed to remove custom shortcut subPath after reset,"
+                   << "leaving a stale ini entry:" << normalized;
+    }
+
+    m_loadedSubPaths.remove(normalized);
+    m_keys.erase(std::remove_if(m_keys.begin(), m_keys.end(),
+                                [&](const KeyConfig &config) { return config.subPath == normalized; }),
+                 m_keys.end());
+
+    if (config)
+        config->deleteLater();
+
+    return true;
+}
+
 void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
 {
     qDebug() << "Loading config from:" << subPath;
@@ -186,9 +321,8 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
         return;
     }
 
-    DConfig *config = DConfig::create(APP_ID,
-                                      isKey ? CONFIG_NAME_SHORTCUT : CONFIG_NAME_GESTURE,
-                                      "/" + subPath, this);
+    DConfig *config = createDConfig(isKey ? CONFIG_NAME_SHORTCUT : CONFIG_NAME_GESTURE,
+                                    subPath, this);
     if (!config->isValid()) {
         qWarning() << "Failed to create DConfig for" << subPath;
         delete config;
@@ -199,10 +333,6 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
     if (isKey) {
         KeyConfig keyConfig = parseKeyConfig(config);
         if (!keyConfig.isValid()) {
-            // isValid() requires enabled && non-empty appId/displayName/hotkeys.
-            // Most commonly this triggers for shipped-disabled hardware keys
-            // (e.g. wlan with enabled=false). Remember the subPath so reload()
-            // doesn't re-attempt and log this every dpkg trigger.
             qWarning() << "Skipping invalid or disabled KeyConfig:" << subPath
                        << "(enabled=" << keyConfig.enabled
                        << ", appId set=" << !keyConfig.appId.isEmpty()
@@ -257,20 +387,22 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             qDebug() << "DConfig value changed:" << subPath << key;
             if (isKey) {
                 KeyConfig updatedConfig = parseKeyConfig(config);
-                for (auto &existing : m_keys) {
-                    if (existing.subPath == subPath) {
-                        existing = updatedConfig;
-                        break;
-                    }
+                auto existing = std::find_if(m_keys.begin(), m_keys.end(),
+                                             [&](const KeyConfig &item) { return item.subPath == subPath; });
+                if (existing != m_keys.end()) {
+                    *existing = updatedConfig;
+                } else {
+                    m_keys.append(updatedConfig);
                 }
                 emit keyConfigChanged(updatedConfig);
             } else {
                 GestureConfig updatedConfig = parseGestureConfig(config);
-                for (auto &existing : m_gestures) {
-                    if (existing.subPath == subPath) {
-                        existing = updatedConfig;
-                        break;
-                    }
+                auto existing = std::find_if(m_gestures.begin(), m_gestures.end(),
+                                             [&](const GestureConfig &item) { return item.subPath == subPath; });
+                if (existing != m_gestures.end()) {
+                    *existing = updatedConfig;
+                } else {
+                    m_gestures.append(updatedConfig);
                 }
                 emit gestureConfigChanged(updatedConfig);
             }
@@ -280,15 +412,10 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
     }
 }
 
-static QString normalizedSubpath(const QString &raw)
-{
-    return raw.startsWith(QLatin1Char('/')) ? raw.mid(1) : raw;
-}
-
 KeyConfig ConfigLoader::parseKeyConfig(DConfig *config)
 {
     KeyConfig keyConfig;
-    keyConfig.subPath = normalizedSubpath(config->subpath());
+    keyConfig.subPath = CustomShortcutStore::normalizeSubPath(config->subpath());
     keyConfig.appId = config->value("appId").toString();
     keyConfig.displayName = config->value("displayName").toString();
     keyConfig.enabled = config->value("enabled").toBool();
@@ -309,7 +436,7 @@ KeyConfig ConfigLoader::parseKeyConfig(DConfig *config)
 GestureConfig ConfigLoader::parseGestureConfig(DConfig *config)
 {
     GestureConfig gestureConfig;
-    gestureConfig.subPath = normalizedSubpath(config->subpath());
+    gestureConfig.subPath = CustomShortcutStore::normalizeSubPath(config->subpath());
     gestureConfig.appId = config->value("appId").toString();
     gestureConfig.displayName = config->value("displayName").toString();
     gestureConfig.enabled = config->value("enabled").toBool();

--- a/src/plugin-qt/shortcut/src/config/configloader.h
+++ b/src/plugin-qt/shortcut/src/config/configloader.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include "config/customshortcutstore.h"
 #include "core/shortcutconfig.h"
 
 #include <QObject>
 #include <QMap>
 #include <QList>
+#include <QSet>
 
 #include <DConfig>
 
@@ -28,8 +30,14 @@ public:
     void scanForConfigs();
     void reload();
     void resetConfig();
-    void updateValue(const QString &id, const QString &key, const QVariant &value);
+    bool updateValue(const QString &id, const QString &key, const QVariant &value);
+    bool canUpdateValue(const QString &id) const;
     void dumpConfigs();
+
+    // Custom shortcut persistence (user-level DConfig + INI)
+    bool saveCustomShortcut(const KeyConfig &config);
+    bool updateCustomShortcut(const KeyConfig &config);
+    bool removeCustomShortcut(const QString &subPath);
 
     QList<KeyConfig> keys() const { return m_keys; }
     QList<GestureConfig> gestures() const { return m_gestures; }
@@ -44,7 +52,7 @@ signals:
 
 private:
     QSet<QString> discoverSubPaths();
-    bool needLoad(const QString &subPath);
+    QSet<QString> scanIniSubPaths(const QString &dirPath);
     void loadConfig(const QString &subPath, bool newOne = false);
     KeyConfig parseKeyConfig(DConfig *config);
     GestureConfig parseGestureConfig(DConfig *config);
@@ -53,4 +61,6 @@ private:
     QList<GestureConfig> m_gestures;
     QMap<QString, DConfig*> m_configs; // subPath(id) -> config, key has no leading /
     QSet<QString> m_loadedSubPaths; // Track all loaded subPaths
+
+    CustomShortcutStore m_customStore;
 };

--- a/src/plugin-qt/shortcut/src/config/customshortcutstore.cpp
+++ b/src/plugin-qt/shortcut/src/config/customshortcutstore.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "customshortcutstore.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QSettings>
+#include <QSignalBlocker>
+#include <QStandardPaths>
+#include <QVariant>
+
+namespace {
+
+const QString APP_ID = "org.deepin.dde.keybinding";
+const QString CONFIG_NAME_SHORTCUT = "org.deepin.shortcut";
+const QString CUSTOM_CONFIG_SUBPATH_DIR = "deepin/dde-services/shortcut";
+const QString CUSTOM_CONFIG_INI = "custom-shortcuts.ini";
+
+const QStringList CustomShortcutKeys = {
+    QStringLiteral("appId"),
+    QStringLiteral("displayName"),
+    QStringLiteral("enabled"),
+    QStringLiteral("modifiable"),
+    QStringLiteral("triggerType"),
+    QStringLiteral("triggerValue"),
+    QStringLiteral("category"),
+    QStringLiteral("hotkeys")
+};
+
+} // namespace
+
+CustomShortcutStore::CustomShortcutStore()
+    : m_iniPath(QDir(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation))
+                        .absoluteFilePath(CUSTOM_CONFIG_SUBPATH_DIR + QLatin1Char('/') + CUSTOM_CONFIG_INI))
+{
+}
+
+QSet<QString> CustomShortcutStore::discoverSubPaths() const
+{
+    QSet<QString> result;
+    const QFileInfo info(m_iniPath);
+    if (!info.exists())
+        return result;
+
+    const QStringList paths = subPaths();
+    for (const QString &subPath : paths)
+        result.insert(subPath);
+    return result;
+}
+
+DConfig *CustomShortcutStore::createConfig(const QString &subPath, QObject *parent) const
+{
+    const QString normalized = normalizeSubPath(subPath);
+    if (normalized.isEmpty()) {
+        qWarning() << "CustomShortcutStore: invalid custom shortcut subPath:" << subPath;
+        return nullptr;
+    }
+    return DConfig::create(APP_ID, CONFIG_NAME_SHORTCUT, QStringLiteral("/") + normalized, parent);
+}
+
+bool CustomShortcutStore::save(const KeyConfig &config, DConfig *configObject) const
+{
+    if (!configObject) {
+        qWarning() << "CustomShortcutStore: missing DConfig object for save:" << config.subPath;
+        return false;
+    }
+
+    const QString subPath = normalizeSubPath(config.subPath);
+    qInfo() << "CustomShortcutStore: saving custom shortcut"
+            << "subPath:" << subPath
+            << "appId:" << config.appId
+            << "displayName:" << config.displayName
+            << "enabled:" << config.enabled
+            << "modifiable:" << config.modifiable
+            << "triggerType:" << config.triggerType
+            << "triggerValue count:" << config.triggerValue.size()
+            << "command length:" << (config.triggerValue.isEmpty() ? 0 : config.triggerValue.first().size())
+            << "category:" << config.category
+            << "hotkeys:" << config.hotkeys;
+
+    {
+        const QSignalBlocker blocker(configObject);
+        configObject->setValue("appId", config.appId);
+        configObject->setValue("displayName", config.displayName);
+        configObject->setValue("enabled", config.enabled);
+        configObject->setValue("modifiable", config.modifiable);
+        configObject->setValue("triggerType", config.triggerType);
+        configObject->setValue("triggerValue", config.triggerValue);
+        configObject->setValue("category", config.category);
+        configObject->setValue("hotkeys", config.hotkeys);
+    }
+
+    QStringList paths = subPaths();
+    if (!paths.contains(subPath))
+        paths.append(subPath);
+    return writeSubPaths(paths);
+}
+
+bool CustomShortcutStore::updateCustomShortcutFields(const KeyConfig &config, DConfig *configObject) const
+{
+    if (!configObject) {
+        qWarning() << "CustomShortcutStore: missing DConfig object for update:" << config.subPath;
+        return false;
+    }
+
+    const QString subPath = normalizeSubPath(config.subPath);
+    qInfo() << "CustomShortcutStore: updating custom shortcut fields"
+            << "subPath:" << subPath
+            << "displayName:" << config.displayName
+            << "triggerValue count:" << config.triggerValue.size()
+            << "command length:" << (config.triggerValue.isEmpty() ? 0 : config.triggerValue.first().size())
+            << "hotkeys:" << config.hotkeys;
+
+    const QSignalBlocker blocker(configObject);
+    const auto setIfChanged = [configObject](const QString &key, const QVariant &value) {
+        if (configObject->value(key) != value)
+            configObject->setValue(key, value);
+    };
+
+    setIfChanged(QStringLiteral("appId"), config.appId);
+    setIfChanged(QStringLiteral("displayName"), config.displayName);
+    setIfChanged(QStringLiteral("enabled"), config.enabled);
+    setIfChanged(QStringLiteral("modifiable"), config.modifiable);
+    setIfChanged(QStringLiteral("triggerType"), config.triggerType);
+    setIfChanged(QStringLiteral("triggerValue"), config.triggerValue);
+    setIfChanged(QStringLiteral("category"), config.category);
+    setIfChanged(QStringLiteral("hotkeys"), config.hotkeys);
+    return true;
+}
+
+bool CustomShortcutStore::removeSubPath(const QString &subPath) const
+{
+    QStringList paths = subPaths();
+    paths.removeAll(normalizeSubPath(subPath));
+    return writeSubPaths(paths);
+}
+
+void CustomShortcutStore::reset(DConfig *configObject, const QString &subPath) const
+{
+    if (!configObject)
+        return;
+
+    const QString normalized = normalizeSubPath(subPath);
+    qInfo() << "CustomShortcutStore: resetting custom shortcut DConfig:" << normalized;
+
+    QStringList resetKeys = configObject->keyList();
+    resetKeys.append(CustomShortcutKeys);
+    resetKeys.removeDuplicates();
+
+    const QSignalBlocker blocker(configObject);
+    for (const QString &key : resetKeys)
+        configObject->reset(key);
+}
+
+QString CustomShortcutStore::normalizeSubPath(const QString &raw)
+{
+    const QString trimmed = raw.trimmed();
+    const QString normalized = trimmed.startsWith(QLatin1Char('/')) ? trimmed.mid(1) : trimmed;
+    if (normalized.isEmpty()
+        || normalized.contains(QStringLiteral(".."))
+        || normalized.contains(QLatin1Char('\\'))
+        || normalized.contains(QChar::Null)) {
+        qWarning() << "CustomShortcutStore: rejected unsafe subPath:" << raw;
+        return QString();
+    }
+    return normalized;
+}
+
+QStringList CustomShortcutStore::subPaths() const
+{
+    QSettings settings(m_iniPath, QSettings::IniFormat);
+    settings.beginGroup("Config");
+    const QVariant subPathsVar = settings.value("SubPaths");
+    QStringList paths;
+    if (subPathsVar.typeId() == QMetaType::QStringList) {
+        paths = subPathsVar.toStringList();
+    } else {
+        paths = subPathsVar.toString().split(",", Qt::SkipEmptyParts);
+    }
+    settings.endGroup();
+
+    for (QString &subPath : paths)
+        subPath = normalizeSubPath(subPath);
+    paths.removeAll(QString());
+    paths.removeDuplicates();
+    paths.sort();
+    return paths;
+}
+
+bool CustomShortcutStore::writeSubPaths(const QStringList &subPaths) const
+{
+    const QFileInfo info(m_iniPath);
+    QDir dir(info.absolutePath());
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        qWarning() << "CustomShortcutStore: failed to create custom shortcut ini dir:" << info.absolutePath();
+        return false;
+    }
+
+    QStringList normalized;
+    normalized.reserve(subPaths.size());
+    for (const QString &subPath : subPaths) {
+        const QString value = normalizeSubPath(subPath);
+        if (!value.isEmpty() && !normalized.contains(value))
+            normalized.append(value);
+    }
+    normalized.sort();
+
+    QSettings settings(m_iniPath, QSettings::IniFormat);
+    settings.beginGroup("Config");
+    settings.setValue("SubPaths", normalized);
+    settings.endGroup();
+    settings.sync();
+
+    if (settings.status() != QSettings::NoError) {
+        qWarning() << "CustomShortcutStore: failed to write custom shortcut ini:" << m_iniPath;
+        return false;
+    }
+    return true;
+}

--- a/src/plugin-qt/shortcut/src/config/customshortcutstore.h
+++ b/src/plugin-qt/shortcut/src/config/customshortcutstore.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "core/shortcutconfig.h"
+
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+#include <DConfig>
+
+DCORE_USE_NAMESPACE
+
+class QObject;
+
+class CustomShortcutStore
+{
+public:
+    CustomShortcutStore();
+
+    QSet<QString> discoverSubPaths() const;
+    DConfig *createConfig(const QString &subPath, QObject *parent) const;
+
+    bool save(const KeyConfig &config, DConfig *configObject) const;
+    bool updateCustomShortcutFields(const KeyConfig &config, DConfig *configObject) const;
+    bool removeSubPath(const QString &subPath) const;
+    void reset(DConfig *configObject, const QString &subPath) const;
+
+    static QString normalizeSubPath(const QString &raw);
+
+private:
+    QStringList subPaths() const;
+    bool writeSubPaths(const QStringList &subPaths) const;
+
+    QString m_iniPath;
+};

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -10,10 +10,12 @@
 #include "translationmanager.h"
 #include "core/shortcutconfig.h"
 #include "qkeysequenceconverter.h"
+#include <qlogging.h>
 
 #include <QDebug>
 #include <QDBusConnection>
 #include <QHash>
+#include <QUuid>
 #include <algorithm>
 
 // Normalize a hotkey from XKB form ("<Control><Alt>T") to Qt PortableText
@@ -34,6 +36,48 @@ static QStringList normalizeHotkeys(const QStringList &hotkeys)
     for (const QString &h : hotkeys)
         out.append(normalizeHotkey(h));
     return out;
+}
+
+constexpr int MaxCustomShortcutCount = 200;
+constexpr int MaxCustomShortcutNameLength = 128;
+constexpr int MaxCustomShortcutCommandLength = 4096;
+constexpr int MaxCustomShortcutHotkeyLength = 256;
+
+static bool containsControlCharacter(const QString &text)
+{
+    for (const QChar ch : text) {
+        const QChar::Category category = ch.category();
+        if (category == QChar::Other_Control
+            || category == QChar::Other_Format
+            || category == QChar::Other_Surrogate
+            || category == QChar::Other_PrivateUse
+            || category == QChar::Other_NotAssigned) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool isValidCustomShortcutName(const QString &name)
+{
+    return !name.isEmpty()
+            && name.size() <= MaxCustomShortcutNameLength
+            && !containsControlCharacter(name);
+}
+
+static bool isValidCustomShortcutCommand(const QString &command)
+{
+    return !command.isEmpty()
+            && command.size() <= MaxCustomShortcutCommandLength
+            && !containsControlCharacter(command);
+}
+
+static bool isValidCustomShortcutHotkey(const QString &hotkey, bool allowEmpty)
+{
+    if (hotkey.isEmpty())
+        return allowEmpty;
+    return hotkey.size() <= MaxCustomShortcutHotkeyLength
+            && !containsControlCharacter(hotkey);
 }
 
 KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *executor,
@@ -67,7 +111,10 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
     
     connect(m_loader, &ConfigLoader::keyConfigChanged, this, &KeybindingManager::onKeyConfigChanged);
     connect(m_loader, &ConfigLoader::keyConfigAdded, this, [this](const KeyConfig &newConfig){
-        if (registerShortcut(newConfig)) {
+        if (newConfig.isDisplayOnly()) {
+            m_keyConfigsMap[newConfig.getId()] = newConfig;
+            emit ShortcutChanged(newConfig.getId(), toShortcutInfo(newConfig));
+        } else if (registerShortcut(newConfig)) {
             m_keyConfigsMap[newConfig.getId()] = newConfig;
             m_keyHandler->commit();
         }
@@ -88,7 +135,9 @@ void KeybindingManager::registerAllShortcuts()
     
     // Register existing configs
     for (const KeyConfig &config : m_loader->keys()) {
-        if (registerShortcut(config)) {
+        if (config.isDisplayOnly()) {
+            m_keyConfigsMap[config.getId()] = config;
+        } else if (registerShortcut(config)) {
             m_keyConfigsMap[config.getId()] = config;
         }
     }
@@ -108,9 +157,9 @@ QList<ShortcutInfo> KeybindingManager::ListAllShortcuts()
     for (const auto &config : m_keyConfigsMap) {
         // Only expose modifiable shortcuts — control center filters out
         // non-modifiable entries to avoid showing read-only items.
-        // Skip shortcuts with no hotkeys (e.g. after ReplaceHotkey stole
-        // the last binding but before the next reload prunes them).
-        if (!config.modifiable || config.hotkeys.isEmpty()) {
+        // Empty hotkeys are still exposed so the control center can show
+        // the existing row as "None" after another shortcut takes its binding.
+        if (!config.modifiable) {
             continue;
         }
         list.append(toShortcutInfo(config));
@@ -199,6 +248,17 @@ ShortcutInfo KeybindingManager::GetShortcut(const QString &id)
     }
 
     return ShortcutInfo();
+}
+
+QString KeybindingManager::GetShortcutCommand(const QString &id)
+{
+    const KeyConfig config = m_keyConfigsMap.value(id);
+    if (config.category == QLatin1String(CategoryKey::Custom)
+        && config.triggerType == static_cast<int>(TriggerType::Command)
+        && !config.triggerValue.isEmpty()) {
+        return config.triggerValue.first();
+    }
+    return QString();
 }
 
 ShortcutInfo KeybindingManager::LookupConflictShortcut(const QString &hotkey)
@@ -315,6 +375,291 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
     return true;
 }
 
+QString KeybindingManager::AddCustomShortcut(const QString &name, const QString &command, const QString &hotkey)
+{
+    const QString displayName = name.trimmed();
+    const QString commandText = command.trimmed();
+    const QString normalizedHotkey = normalizeHotkey(hotkey);
+
+    if (runtimeCustomShortcutCount() >= MaxCustomShortcutCount) {
+        qWarning() << "AddCustomShortcut: custom shortcut count limit reached";
+        return QString();
+    }
+
+    if (!isValidCustomShortcutName(displayName)
+        || !isValidCustomShortcutCommand(commandText)
+        || !isValidCustomShortcutHotkey(normalizedHotkey, false)) {
+        qWarning() << "AddCustomShortcut: invalid input";
+        return QString();
+    }
+
+    KeyConfig config;
+    config.appId = QStringLiteral("org.deepin.dde.keybinding");
+    config.subPath = createCustomShortcutId();
+    config.keyEventFlags = KeyEventFlag::Release;
+    updateCustomShortcutConfigFields(config, displayName, commandText, normalizedHotkey);
+
+    ConflictShortcutState conflictState;
+    if (!tryHandleConflictShortcut(normalizedHotkey, conflictState))
+        return QString();
+
+    const bool hasConflict = conflictState.handled;
+    const QString conflictId = conflictState.id;
+    KeyConfig conflictConfig = conflictState.config;
+    const QStringList oldConflictHotkeys = conflictState.oldHotkeys;
+
+    const QStringList excludedIds = hasConflict ? QStringList{conflictId} : QStringList();
+    if (!registerShortcut(config, excludedIds)) {
+        qWarning() << "AddCustomShortcut: failed to register" << config.getId();
+        if (hasConflict) {
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+            m_keyHandler->commitSync();
+        }
+        return QString();
+    }
+
+    bool conflictRegistered = true;
+    if (hasConflict && !conflictConfig.hotkeys.isEmpty())
+        conflictRegistered = registerShortcut(conflictConfig, excludedIds);
+
+    if (!conflictRegistered) {
+        qWarning() << "AddCustomShortcut: failed to re-register conflict shortcut" << conflictId;
+        unregisterShortcut(config.getId());
+        conflictConfig.hotkeys = oldConflictHotkeys;
+        registerShortcut(conflictConfig, excludedIds);
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (!m_keyHandler->commitSync()) {
+        qWarning() << "AddCustomShortcut: commit failed, rolling back" << config.getId();
+        unregisterShortcut(config.getId());
+        if (hasConflict) {
+            unregisterShortcut(conflictId);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (hasConflict) {
+        m_keyConfigsMap[conflictId] = conflictConfig;
+    }
+
+    if (!m_loader->saveCustomShortcut(config)) {
+        qWarning() << "AddCustomShortcut: failed to persist custom shortcut, rolling back" << config.getId();
+        unregisterShortcut(config.getId());
+        if (hasConflict) {
+            unregisterShortcut(conflictId);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+            m_keyConfigsMap[conflictId] = conflictConfig;
+            emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
+        }
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (hasConflict && !m_loader->updateValue(conflictId, "hotkeys", conflictConfig.hotkeys)) {
+        qWarning() << "AddCustomShortcut: failed to persist conflict shortcut, rolling back" << conflictId;
+        m_loader->removeCustomShortcut(config.getId());
+        unregisterShortcut(config.getId());
+        unregisterShortcut(conflictId);
+        conflictConfig.hotkeys = oldConflictHotkeys;
+        registerShortcut(conflictConfig, excludedIds);
+        m_keyConfigsMap[conflictId] = conflictConfig;
+        emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
+        m_keyHandler->commitSync();
+        return QString();
+    }
+
+    if (hasConflict) {
+        emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
+    }
+    m_keyConfigsMap[config.getId()] = config;
+    emit ShortcutChanged(config.getId(), toShortcutInfo(config));
+    return config.getId();
+}
+
+bool KeybindingManager::ModifyCustomShortcut(const QString &id, const QString &name,
+                                             const QString &command, const QString &hotkey)
+{
+    if (!m_keyConfigsMap.contains(id)) {
+        return false;
+    }
+
+    KeyConfig oldConfig = m_keyConfigsMap[id];
+    if (!isRuntimeCustomShortcut(oldConfig)) {
+        qWarning() << "ModifyCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
+        return false;
+    }
+
+    const QString displayName = name.trimmed();
+    const QString commandText = command.trimmed();
+    const QString normalizedHotkey = normalizeHotkey(hotkey);
+    if (!isValidCustomShortcutName(displayName)
+        || !isValidCustomShortcutCommand(commandText)
+        || !isValidCustomShortcutHotkey(normalizedHotkey, true)) {
+        qWarning() << "ModifyCustomShortcut: invalid input" << id;
+        return false;
+    }
+
+    KeyConfig newConfig = oldConfig;
+    updateCustomShortcutConfigFields(newConfig, displayName, commandText, normalizedHotkey);
+
+    const bool hotkeysChanged = oldConfig.hotkeys != newConfig.hotkeys;
+    if (!hotkeysChanged) {
+        if (oldConfig == newConfig)
+            return true;
+
+        if (!m_loader->updateCustomShortcut(newConfig)) {
+            qWarning() << "ModifyCustomShortcut: failed to persist custom shortcut:" << id;
+            return false;
+        }
+
+        m_keyConfigsMap[id] = newConfig;
+        emit ShortcutChanged(id, toShortcutInfo(newConfig));
+        return true;
+    }
+
+    ConflictShortcutState conflictState;
+    if (!tryHandleConflictShortcut(normalizedHotkey, conflictState, id))
+        return false;
+
+    const bool hasConflict = conflictState.handled;
+    const QString conflictId = conflictState.id;
+    KeyConfig conflictConfig = conflictState.config;
+    const QStringList oldConflictHotkeys = conflictState.oldHotkeys;
+
+    unregisterShortcut(id);
+    const QStringList excludedIds = hasConflict ? QStringList{id, conflictId} : QStringList{id};
+    bool newRegistered = true;
+    if (!newConfig.hotkeys.isEmpty())
+        newRegistered = registerShortcut(newConfig, excludedIds);
+    if (!newRegistered) {
+        qWarning() << "ModifyCustomShortcut: failed to register" << id;
+        if (hasConflict) {
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    bool conflictRegistered = true;
+    if (hasConflict && !conflictConfig.hotkeys.isEmpty())
+        conflictRegistered = registerShortcut(conflictConfig, QStringList{id, conflictId});
+
+    if (!conflictRegistered) {
+        qWarning() << "ModifyCustomShortcut: failed to re-register conflict shortcut" << conflictId;
+        unregisterShortcut(id);
+        if (hasConflict) {
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        if (registerShortcut(oldConfig, QStringList{id}))
+            m_keyHandler->commitSync();
+        return false;
+    }
+
+    if (!m_keyHandler->commitSync()) {
+        qWarning() << "ModifyCustomShortcut: commit failed, rolling back" << id;
+        unregisterShortcut(id);
+        if (hasConflict) {
+            unregisterShortcut(conflictId);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+        }
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    if (hasConflict) {
+        m_keyConfigsMap[conflictId] = conflictConfig;
+    }
+
+    if (!m_loader->updateCustomShortcut(newConfig)) {
+        qWarning() << "ModifyCustomShortcut: failed to persist custom shortcut, rolling back" << id;
+        if (!m_loader->updateCustomShortcut(oldConfig)) {
+            qCritical() << "ModifyCustomShortcut: failed to restore persisted custom shortcut during rollback" << id;
+        }
+        unregisterShortcut(id);
+        if (hasConflict) {
+            unregisterShortcut(conflictId);
+            conflictConfig.hotkeys = oldConflictHotkeys;
+            registerShortcut(conflictConfig, excludedIds);
+            m_keyConfigsMap[conflictId] = conflictConfig;
+            emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
+        }
+        if (registerShortcut(oldConfig, QStringList{id}))
+            m_keyHandler->commitSync();
+        return false;
+    }
+
+    if (hasConflict && !m_loader->updateValue(conflictId, "hotkeys", conflictConfig.hotkeys)) {
+        qWarning() << "ModifyCustomShortcut: failed to persist conflict shortcut, rolling back" << conflictId;
+        if (!m_loader->updateCustomShortcut(oldConfig)) {
+            qCritical() << "ModifyCustomShortcut: failed to restore persisted custom shortcut during conflict rollback" << id;
+        }
+        unregisterShortcut(id);
+        unregisterShortcut(conflictId);
+        conflictConfig.hotkeys = oldConflictHotkeys;
+        registerShortcut(conflictConfig, excludedIds);
+        m_keyConfigsMap[conflictId] = conflictConfig;
+        if (registerShortcut(oldConfig, QStringList{id}))
+            m_keyHandler->commitSync();
+        emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
+        return false;
+    }
+
+    if (hasConflict) {
+        emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
+    }
+    m_keyConfigsMap[id] = newConfig;
+    emit ShortcutChanged(id, toShortcutInfo(newConfig));
+    return true;
+}
+
+bool KeybindingManager::DeleteCustomShortcut(const QString &id)
+{
+    if (!m_keyConfigsMap.contains(id)) {
+        return false;
+    }
+
+    KeyConfig oldConfig = m_keyConfigsMap[id];
+    if (!isRuntimeCustomShortcut(oldConfig)) {
+        qWarning() << "DeleteCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
+        return false;
+    }
+
+    unregisterShortcut(id);
+    if (!m_keyHandler->commitSync()) {
+        qWarning() << "DeleteCustomShortcut: commit failed, restoring" << id;
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    if (!m_loader->removeCustomShortcut(id)) {
+        qWarning() << "DeleteCustomShortcut: failed to remove persisted custom shortcut, restoring" << id;
+        if (registerShortcut(oldConfig, QStringList{id})) {
+            m_keyHandler->commitSync();
+        }
+        return false;
+    }
+
+    m_keyConfigsMap.remove(id);
+    emit ShortcutRemoved(id);
+    return true;
+}
+
 bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
 {
     if (id1 == id2)
@@ -329,6 +674,12 @@ bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
     if (!config1.enabled || !config1.modifiable || !config2.enabled || !config2.modifiable) {
         qWarning() << "SwapHotkeys: both shortcuts must be enabled and modifiable:"
                     << id1 << id2;
+        return false;
+    }
+    if (!canPersistShortcutHotkeys(config1) || !canPersistShortcutHotkeys(config2)) {
+        qWarning() << "SwapHotkeys: both shortcuts must have writable configs:"
+                    << id1 << m_loader->canUpdateValue(id1)
+                    << id2 << m_loader->canUpdateValue(id2);
         return false;
     }
 
@@ -415,6 +766,12 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
         qWarning() << "ReplaceHotkey: conflict shortcut not modifiable or enabled:" << conflictId;
         return false;
     }
+    if (!canPersistShortcutHotkeys(targetConfig) || !canPersistShortcutHotkeys(conflictConfig)) {
+        qWarning() << "ReplaceHotkey: target and conflict shortcuts must have writable configs:"
+                    << targetId << m_loader->canUpdateValue(targetId)
+                    << conflictId << m_loader->canUpdateValue(conflictId);
+        return false;
+    }
 
     const QString normalized = normalizeHotkey(newHotkey);
 
@@ -465,14 +822,7 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
     m_loader->updateValue(targetId, "hotkeys", targetConfig.hotkeys);
     m_loader->updateValue(conflictId, "hotkeys", conflictConfig.hotkeys);
     emit ShortcutChanged(targetId, toShortcutInfo(targetConfig));
-    if (conflictConfig.hotkeys.isEmpty()) {
-        // Last hotkey was stolen.
-        // The shortcut stays in dconfig with empty hotkeys; on next load
-        // registerShortcut will skip it (isValid requires non-empty hotkeys).
-        emit ShortcutRemoved(conflictId);
-    } else {
-        emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
-    }
+    emit ShortcutChanged(conflictId, toShortcutInfo(conflictConfig));
 
     return true;
 }
@@ -530,6 +880,8 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &config)
         if (!config.enabled) {
             // new one, but disabled, skip
             return;
+        } else if (config.isDisplayOnly()) {
+            m_keyConfigsMap[config.getId()] = config;
         } else {
             // new one, enable
             if (registerShortcut(config)) {
@@ -539,6 +891,9 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &config)
         }
     } else { // exist
         KeyConfig &old = m_keyConfigsMap[config.getId()];
+        if (old == config)
+            return;
+
         if (!config.enabled) {
             // enable->disable
             m_keyHandler->unregisterKey(config.getId());
@@ -548,7 +903,9 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &config)
             // update
             m_keyHandler->unregisterKey(config.getId());
             m_keyConfigsMap.remove(config.getId());
-            if (registerShortcut(config)) {
+            if (config.isDisplayOnly()) {
+                m_keyConfigsMap[config.getId()] = config;
+            } else if (registerShortcut(config)) {
                 m_keyConfigsMap[config.getId()] = config;
             }
             m_keyHandler->commit();
@@ -591,18 +948,18 @@ void KeybindingManager::onKeyActivated(const QString &shortcutId)
     }
 }
 
-bool KeybindingManager::registerShortcut(const KeyConfig &config)
+bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringList &excludeIds)
 {
-    if (!config.isValid()) {
-        qWarning() << "Shortcut is disabled or invalid, skipping registration:"
-                    << "Enabled:" << config.enabled
-                    << "AppId:" << config.appId
-                    << "DisplayName:" << config.displayName
-                    << "hotkeys:" << config.hotkeys;
+    if (!config.canRegister()) {
+        qWarning() << "Shortcut can not be registered, skipping:"
+                   << "Enabled:" << config.enabled
+                   << "AppId:" << config.appId
+                   << "DisplayName:" << config.displayName
+                   << "hotkeys:" << config.hotkeys;
         return false;
     }
 
-    if (m_keyConfigsMap.contains(config.getId())) {
+    if (m_keyConfigsMap.contains(config.getId()) && !excludeIds.contains(config.getId())) {
         qWarning() << "Shortcut conflict detected during init: has same appId and displayName"
                     << "hotkeys:" << config.hotkeys
                     << "Conflicts with:" << m_keyConfigsMap[config.getId()].hotkeys
@@ -629,7 +986,7 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config)
         // Check for conflicts before registering
         for (const QString &hotkey : normalHotkeys) {
             auto shortcutInfo = LookupConflictShortcut(hotkey);
-            if (!shortcutInfo.id.isEmpty()) {
+            if (!shortcutInfo.id.isEmpty() && !excludeIds.contains(shortcutInfo.id)) {
                 qWarning() << "Shortcut conflict detected during init:"
                             << "Config appId:" << config.appId
                             << "Config displayName:" << config.displayName
@@ -662,34 +1019,55 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config)
     return registered;
 }
 
-QString KeybindingManager::checkConflictForConfig(const KeyConfig &config, const QString &excludeId)
+void KeybindingManager::unregisterShortcut(const QString &id)
 {
-    QString currentId = config.getId();
-    
-    // Check each hotkey in the config
-    for (const QString &hotkey : config.hotkeys) {
-        // Search through all registered shortcuts
-        for (const KeyConfig &existingConfig : m_keyConfigsMap) {
-            QString existingId = existingConfig.getId();
-            
-            // Skip if this is the config we're excluding (self-check)
-            if (!excludeId.isEmpty() && existingId == excludeId) {
-                continue;
-            }
-            
-            // Skip if not enabled
-            if (!existingConfig.enabled) {
-                continue;
-            }
-            
-            // Check if hotkey conflicts
-            if (existingConfig.hotkeys.contains(hotkey)) {
-                return existingId; // Return the conflicting shortcut ID
-            }
-        }
+    m_keyHandler->unregisterKey(id);
+    m_specialKeyHandler->unregisterKey(id);
+}
+
+bool KeybindingManager::isRuntimeCustomShortcut(const KeyConfig &config) const
+{
+    return config.category == QLatin1String(CategoryKey::Custom)
+            && config.modifiable
+            && config.subPath.startsWith(QStringLiteral("org.deepin.dde.keybinding.shortcut.custom."));
+}
+
+bool KeybindingManager::canPersistShortcutHotkeys(const KeyConfig &config) const
+{
+    return config.modifiable && m_loader->canUpdateValue(config.getId());
+}
+
+int KeybindingManager::runtimeCustomShortcutCount() const
+{
+    int count = 0;
+    for (const KeyConfig &config : m_keyConfigsMap) {
+        if (isRuntimeCustomShortcut(config))
+            ++count;
     }
-    
-    return QString(); // No conflict
+    return count;
+}
+
+QString KeybindingManager::createCustomShortcutId() const
+{
+    QString id;
+    do {
+        id = QStringLiteral("org.deepin.dde.keybinding.shortcut.custom.")
+                + QUuid::createUuid().toString(QUuid::WithoutBraces);
+    } while (m_keyConfigsMap.contains(id));
+    return id;
+}
+
+void KeybindingManager::updateCustomShortcutConfigFields(KeyConfig &config, const QString &displayName,
+                                                         const QString &commandText,
+                                                         const QString &normalizedHotkey) const
+{
+    config.displayName = displayName;
+    config.category = QString::fromLatin1(CategoryKey::Custom);
+    config.enabled = true;
+    config.modifiable = true;
+    config.triggerType = static_cast<int>(TriggerType::Command);
+    config.triggerValue = QStringList{commandText};
+    config.hotkeys = normalizedHotkey.isEmpty() ? QStringList() : QStringList{normalizedHotkey};
 }
 
 ShortcutInfo KeybindingManager::toShortcutInfo(const KeyConfig &config)
@@ -747,4 +1125,40 @@ void KeybindingManager::SetCapsLockState(uint state)
             emit CapsLockStateChanged(state);
         }
     }
+}
+
+bool KeybindingManager::tryHandleConflictShortcut(const QString &hotkey, ConflictShortcutState &state,
+                                                  const QString &selfId)
+{
+    state = ConflictShortcutState();
+
+    const QString normalizedHotkey = normalizeHotkey(hotkey);
+    ShortcutInfo conflictInfo = LookupConflictShortcut(normalizedHotkey);
+    if (conflictInfo.id.isEmpty() || conflictInfo.id == selfId) {
+        return true;
+    }
+
+    if (!m_keyConfigsMap.contains(conflictInfo.id)) {
+        qWarning() << "tryHandleConflictShortcut: conflict shortcut is missing:" << conflictInfo.id;
+        return false;
+    }
+
+    KeyConfig conflictConfig = m_keyConfigsMap.value(conflictInfo.id);
+    if (!canPersistShortcutHotkeys(conflictConfig)) {
+        qWarning() << "tryHandleConflictShortcut: conflict shortcut can not be replaced:"
+                    << conflictInfo.id
+                    << "modifiable:" << conflictConfig.modifiable
+                    << "has writable config:" << m_loader->canUpdateValue(conflictInfo.id);
+        return false;
+    }
+
+    state.handled = true;
+    state.id = conflictInfo.id;
+    state.oldHotkeys = conflictConfig.hotkeys;
+
+    unregisterShortcut(conflictInfo.id);
+    conflictConfig.hotkeys.removeOne(normalizedHotkey);
+    state.config = conflictConfig;
+
+    return true;
 }

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -76,11 +76,15 @@ public slots:
     Q_SCRIPTABLE QList<CategoryInfo> ListCategories();
 
     Q_SCRIPTABLE ShortcutInfo GetShortcut(const QString &id);
+    Q_SCRIPTABLE QString GetShortcutCommand(const QString &id);
     Q_SCRIPTABLE ShortcutInfo LookupConflictShortcut(const QString &hotkey);
     
     Q_SCRIPTABLE QList<ShortcutInfo> SearchShortcuts(const QString &keyword);
     Q_SCRIPTABLE bool ModifyHotkeys(const QString &id, const QStringList &newHotkeys);
     Q_SCRIPTABLE bool Disable(const QString &id);
+    Q_SCRIPTABLE QString AddCustomShortcut(const QString &name, const QString &command, const QString &hotkey);
+    Q_SCRIPTABLE bool ModifyCustomShortcut(const QString &id, const QString &name, const QString &command, const QString &hotkey);
+    Q_SCRIPTABLE bool DeleteCustomShortcut(const QString &id);
 
     // Atomically swap the hotkeys of two shortcuts in a single compositor commit.
     Q_SCRIPTABLE bool SwapHotkeys(const QString &id1, const QString &id2);
@@ -112,11 +116,27 @@ private slots:
     ShortcutInfo toShortcutInfo(const KeyConfig &config);
 
 private:
-    bool registerShortcut(const KeyConfig &config);
-    QString checkConflictForConfig(const KeyConfig &config, const QString &excludeId = QString());
+    bool registerShortcut(const KeyConfig &config, const QStringList &excludeIds = QStringList());
+    void unregisterShortcut(const QString &id);
     void rollbackRegistration(const QString &id1, const QString &id2,
                               KeyConfig &config1, KeyConfig &config2,
                               const QStringList &hotkeys1, const QStringList &hotkeys2);
+    bool isRuntimeCustomShortcut(const KeyConfig &config) const;
+    bool canPersistShortcutHotkeys(const KeyConfig &config) const;
+    int runtimeCustomShortcutCount() const;
+    QString createCustomShortcutId() const;
+    void updateCustomShortcutConfigFields(KeyConfig &config, const QString &displayName,
+                                          const QString &commandText,
+                                          const QString &normalizedHotkey) const;
+
+    struct ConflictShortcutState {
+        bool handled = false;
+        QString id;
+        KeyConfig config;
+        QStringList oldHotkeys;
+    };
+    bool tryHandleConflictShortcut(const QString &hotkey, ConflictShortcutState &state,
+                                   const QString &selfId = QString());
 
 
     ConfigLoader *m_loader;
@@ -160,5 +180,3 @@ inline const QDBusArgument &operator>>(const QDBusArgument &argument, CategoryIn
     argument.endStructure();
     return argument;
 }
-
-

--- a/src/plugin-qt/shortcut/src/core/shortcutconfig.h
+++ b/src/plugin-qt/shortcut/src/core/shortcutconfig.h
@@ -42,6 +42,17 @@ struct BaseConfig
     QStringList triggerValue;   // Command args, AppID, or Action Enum Value (as string list)
 
     QString getId() const { return subPath; }
+    bool operator==(const BaseConfig &other) const {
+        return appId == other.appId
+                && subPath == other.subPath
+                && displayName == other.displayName
+                && category == other.category
+                && enabled == other.enabled
+                && modifiable == other.modifiable
+                && triggerType == other.triggerType
+                && triggerValue == other.triggerValue;
+    }
+    bool operator!=(const BaseConfig &other) const { return !(*this == other); }
 };
 
 // Keyboard shortcut configuration
@@ -52,7 +63,17 @@ struct KeyConfig : public BaseConfig
 
     KeyConfig() : keyEventFlags(KeyEventFlag::Release) {} // Default to release
 
-    bool isValid() const { return enabled && !appId.isEmpty() && !displayName.isEmpty() && !hotkeys.isEmpty(); }
+    bool isValid() const { return enabled && !appId.isEmpty() && !displayName.isEmpty(); }
+    bool canRegister() const { return isValid() && !hotkeys.isEmpty(); }
+    // Valid enough to display (has identity) but carries no key binding — shown
+    // as "None" after another shortcut takes its binding.
+    bool isDisplayOnly() const { return enabled && modifiable && !appId.isEmpty() && !displayName.isEmpty() && hotkeys.isEmpty(); }
+    bool operator==(const KeyConfig &other) const {
+        return static_cast<const BaseConfig &>(*this) == static_cast<const BaseConfig &>(other)
+                && hotkeys == other.hotkeys
+                && keyEventFlags == other.keyEventFlags;
+    }
+    bool operator!=(const KeyConfig &other) const { return !(*this == other); }
 };
 
 enum class GestureType {
@@ -68,6 +89,13 @@ struct GestureConfig : public BaseConfig
     int direction;          // 0: None, 1: Down, 2: Left, 3: Up, 4: Right
 
     bool isValid() const { return enabled && !appId.isEmpty() && !displayName.isEmpty() && gestureType > 0 && fingerCount > 0; }
+    bool operator==(const GestureConfig &other) const {
+        return static_cast<const BaseConfig &>(*this) == static_cast<const BaseConfig &>(other)
+                && gestureType == other.gestureType
+                && fingerCount == other.fingerCount
+                && direction == other.direction;
+    }
+    bool operator!=(const GestureConfig &other) const { return !(*this == other); }
 };
 
 Q_DECLARE_METATYPE(KeyConfig)


### PR DESCRIPTION
## Summary
- Add custom shortcut CRUD persistence and runtime display-only support.
- Refactor custom shortcut field construction and conflict handling helpers.
- Harden custom shortcut subpath validation and rollback logging.

## Test plan
- cmake --build build --target plugin-dde-shortcut