### PR TITLE
fix(xsettings): restrict service to X11 session only

### DIFF
--- a/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
+++ b/src/plugin-qt/xsettings/misc/org.deepin.dde.XSettings1.service
@@ -3,6 +3,7 @@ Description=org.deepin.dde.XSettings1
 RefuseManualStart=no
 RefuseManualStop=no
 CollectMode=inactive-or-failed
+ConditionEnvironment=XDG_SESSION_TYPE=x11
 
 PartOf=dde-session-pre.target
 Before=dde-session-pre.target

--- a/src/plugin-qt/xsettings/misc/plugin-dde-xsettings.json
+++ b/src/plugin-qt/xsettings/misc/plugin-dde-xsettings.json
@@ -3,6 +3,9 @@
   "libPath": "libplugin-dde-xsettings.so",
   "startType": "Resident",
   "pluginType": "qt",
+  "condition": {
+    "sessionType": "x11"
+  },
   "policy": [
     {
       "path": "/org/deepin/dde/XSettings1"


### PR DESCRIPTION
Limit the XSettings service and plugin to run only under X11 sessions, skipping Wayland.

PMS: BUG-367635