### PR TITLE
chore: bump version to 1.0.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-services (1.0.35) unstable; urgency=medium
+
+  * fix(build): add libxcb-xinput-dev to Build-Depends
+
+ -- zhaoyingzhen <zhaoyingzhen@uniontech.com>  Fri, 24 Jul 2026 10:00:00 +0800
+
 dde-services (1.0.34) unstable; urgency=medium
 
   * feat(shortcut): complete X11 shortcut and gesture migration


### PR DESCRIPTION
update changelog to 1.0.35

## Summary by Sourcery

Chores:
- Bump Debian changelog version entry to 1.0.35.