### PR TITLE
fix: clamp Treeland brightness at 10 percent

### DIFF
--- a/src/plugin-qt/shortcut/tests/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/tests/CMakeLists.txt
@@ -4,6 +4,21 @@
 
 find_package(Qt6 REQUIRED COMPONENTS Test)
 
+add_executable(tst-brightnesspolicy
+    tst_brightnesspolicy.cpp
+)
+
+target_include_directories(tst-brightnesspolicy PRIVATE
+    ../tools/dde-shortcut-tool
+)
+
+target_link_libraries(tst-brightnesspolicy PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME shortcut-brightnesspolicy COMMAND tst-brightnesspolicy)
+
 add_executable(tst-physicalkeyalias
     tst_physicalkeyalias.cpp
     ../src/core/physicalkeyalias.cpp

--- a/src/plugin-qt/shortcut/tests/tst_brightnesspolicy.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_brightnesspolicy.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <QtTest>
+
+#include "constant.h"
+
+class BrightnessPolicyTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void clampsAtLowerBound();
+    void clampsAtUpperBound();
+    void keepsValueInsideRange();
+};
+
+void BrightnessPolicyTest::clampsAtLowerBound()
+{
+    QCOMPARE(Brightness::adjustedValue(10.0, false), 10.0);
+    QCOMPARE(Brightness::adjustedValue(12.0, false), 10.0);
+}
+
+void BrightnessPolicyTest::clampsAtUpperBound()
+{
+    QCOMPARE(Brightness::adjustedValue(100.0, true), 100.0);
+}
+
+void BrightnessPolicyTest::keepsValueInsideRange()
+{
+    QCOMPARE(Brightness::adjustedValue(50.0, false), 45.0);
+    QCOMPARE(Brightness::adjustedValue(50.0, true), 55.0);
+}
+
+QTEST_APPLESS_MAIN(BrightnessPolicyTest)
+
+#include "tst_brightnesspolicy.moc"

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/constant.h
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/constant.h
@@ -45,6 +45,26 @@ enum PowerAction {
     PowerActionShowUI = 4
 };
 
+namespace Brightness {
+
+constexpr double Step = 5.0;
+constexpr double Minimum = 10.0;
+constexpr double Maximum = 100.0;
+
+inline double adjustedValue(double current, bool raised)
+{
+    const double value = current + (raised ? Step : -Step);
+    if (value < Minimum) {
+        return Minimum;
+    }
+    if (value > Maximum) {
+        return Maximum;
+    }
+    return value;
+}
+
+} // namespace Brightness
+
 namespace Config {
 
 // DConfig App ID

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/treelandbrightnesscontroller.cpp
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/treelandbrightnesscontroller.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "treelandbrightnesscontroller.h"
+#include "constant.h"
 
 #include <QDebug>
 #include <QDir>
@@ -17,7 +18,6 @@
 
 namespace {
 
-constexpr double BrightnessStep = 5.0;
 constexpr int BrightnessCommitTimeoutMs = 1000;
 constexpr int BrightnessLockTimeoutMs = 1500;
 
@@ -49,8 +49,7 @@ double TreelandColorControl::brightness() const
 
 double TreelandColorControl::changeBrightness(bool raised)
 {
-    const double delta = raised ? BrightnessStep : -BrightnessStep;
-    const double target = std::clamp(m_brightness + delta, 0.0, 100.0);
+    const double target = Brightness::adjustedValue(m_brightness, raised);
 
     set_brightness(wl_fixed_from_double(target));
     commit();


### PR DESCRIPTION
fix: clamp Treeland brightness at 10 percent

1. Centralize the brightness step and [10, 100] bounds
2. Apply the shared policy to Treeland brightness changes
3. Add QtTest coverage for lower and upper boundaries

Influence:
1. Prevent brightness-down from producing values below Treeland's supported minimum
2. Preserve 5-point increments and the 100 percent upper bound
3. Verify the policy with unit tests and debug-machine runtime validation

fix: 将 Treeland 亮度下限限制为 10%

1. 统一亮度步长及 [10, 100] 边界
2. 在 Treeland 亮度调整中使用统一策略
3. 增加亮度上下限 QtTest 覆盖

Influence:
1. 防止亮度降低快捷键产生低于 Treeland 支持下限的值
2. 保持 5% 步进和 100% 上限
3. 已通过单测及调试机运行时验证

PMS: BUG-371285

## Summary by Sourcery

Enforce a shared brightness policy with clamped bounds and apply it to Treeland brightness control.

Bug Fixes:
- Prevent Treeland brightness from being reduced below its supported 10% minimum via keyboard shortcuts.

Enhancements:
- Introduce a centralized brightness policy with fixed 5% steps and [10%, 100%] bounds for reuse across shortcut tooling.

Tests:
- Add QtTest-based unit tests to verify brightness clamping at lower and upper bounds and correct stepping within the valid range.