### PR TITLE
refactor: move Treeland brightness policy into color control

### DIFF
--- a/src/plugin-qt/shortcut/tests/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/tests/CMakeLists.txt
@@ -10,12 +10,17 @@ add_executable(tst-brightnesspolicy
 
 target_include_directories(tst-brightnesspolicy PRIVATE
     ../tools/dde-shortcut-tool
+    $<TARGET_PROPERTY:dde-shortcut-tool,BINARY_DIR>
 )
 
 target_link_libraries(tst-brightnesspolicy PRIVATE
     Qt6::Core
+    Qt6::Gui
     Qt6::Test
+    Qt6::WaylandClient
 )
+
+add_dependencies(tst-brightnesspolicy dde-shortcut-tool)
 
 add_test(NAME shortcut-brightnesspolicy COMMAND tst-brightnesspolicy)
 

--- a/src/plugin-qt/shortcut/tests/tst_brightnesspolicy.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_brightnesspolicy.cpp
@@ -4,7 +4,9 @@
 
 #include <QtTest>
 
-#include "constant.h"
+#include "treelandbrightnesscontroller.h"
+
+using TreelandBrightnessPrivate::TreelandColorControl;
 
 class BrightnessPolicyTest : public QObject
 {
@@ -18,19 +20,19 @@ private Q_SLOTS:
 
 void BrightnessPolicyTest::clampsAtLowerBound()
 {
-    QCOMPARE(Brightness::adjustedValue(10.0, false), 10.0);
-    QCOMPARE(Brightness::adjustedValue(12.0, false), 10.0);
+    QCOMPARE(TreelandColorControl::adjustedValue(10.0, false), 10.0);
+    QCOMPARE(TreelandColorControl::adjustedValue(12.0, false), 10.0);
 }
 
 void BrightnessPolicyTest::clampsAtUpperBound()
 {
-    QCOMPARE(Brightness::adjustedValue(100.0, true), 100.0);
+    QCOMPARE(TreelandColorControl::adjustedValue(100.0, true), 100.0);
 }
 
 void BrightnessPolicyTest::keepsValueInsideRange()
 {
-    QCOMPARE(Brightness::adjustedValue(50.0, false), 45.0);
-    QCOMPARE(Brightness::adjustedValue(50.0, true), 55.0);
+    QCOMPARE(TreelandColorControl::adjustedValue(50.0, false), 45.0);
+    QCOMPARE(TreelandColorControl::adjustedValue(50.0, true), 55.0);
 }
 
 QTEST_APPLESS_MAIN(BrightnessPolicyTest)

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/constant.h
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/constant.h
@@ -45,26 +45,6 @@ enum PowerAction {
     PowerActionShowUI = 4
 };
 
-namespace Brightness {
-
-constexpr double Step = 5.0;
-constexpr double Minimum = 10.0;
-constexpr double Maximum = 100.0;
-
-inline double adjustedValue(double current, bool raised)
-{
-    const double value = current + (raised ? Step : -Step);
-    if (value < Minimum) {
-        return Minimum;
-    }
-    if (value > Maximum) {
-        return Maximum;
-    }
-    return value;
-}
-
-} // namespace Brightness
-
 namespace Config {
 
 // DConfig App ID

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/treelandbrightnesscontroller.cpp
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/treelandbrightnesscontroller.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "treelandbrightnesscontroller.h"
-#include "constant.h"
 
 #include <QDebug>
 #include <QDir>
@@ -49,7 +48,7 @@ double TreelandColorControl::brightness() const
 
 double TreelandColorControl::changeBrightness(bool raised)
 {
-    const double target = Brightness::adjustedValue(m_brightness, raised);
+    const double target = adjustedValue(m_brightness, raised);
 
     set_brightness(wl_fixed_from_double(target));
     commit();

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/treelandbrightnesscontroller.h
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/treelandbrightnesscontroller.h
@@ -30,12 +30,28 @@ public:
     double changeBrightness(bool raised);
     void setResultHandler(std::function<void(bool)> handler);
 
+    static constexpr double adjustedValue(double current, bool raised)
+    {
+        const double value = current + (raised ? BrightnessStep : -BrightnessStep);
+        if (value < MinimumBrightness) {
+            return MinimumBrightness;
+        }
+        if (value > MaximumBrightness) {
+            return MaximumBrightness;
+        }
+        return value;
+    }
+
 protected:
     void treeland_output_color_control_v1_result(uint32_t success) override;
     void treeland_output_color_control_v1_color_temperature(uint32_t temperature) override;
     void treeland_output_color_control_v1_brightness(wl_fixed_t brightness) override;
 
 private:
+    static constexpr double BrightnessStep = 5.0;
+    static constexpr double MinimumBrightness = 10.0;
+    static constexpr double MaximumBrightness = 100.0;
+
     double m_brightness = -1.0;
     std::function<void(bool)> m_resultHandler;
 };


### PR DESCRIPTION
refactor: move Treeland brightness policy into color control

1. Move the brightness step and limits from constant.h into TreelandColorControl
2. Move adjustedValue into the class and keep it constexpr
3. Update brightness policy tests to use the class-scoped helper

Influence:
1. Preserve the 5% brightness step and [10, 100] boundaries
2. Keep constant.h limited to shared constants and configuration
3. Verify dde-shortcut-tool builds and all brightness policy tests pass

refactor: 将 Treeland 亮度策略移入颜色控制类

1. 将亮度步长和上下限从constant.h移入TreelandColorControl
2. 将adjustedValue移入类内并保持constexpr
3. 更新亮度策略单测以使用类内方法

Influence:
1. 保持5%亮度步长及[10, 100]边界不变
2. 确保constant.h仅存放公共常量和配置
3. 验证dde-shortcut-tool编译通过且亮度策略单测全部通过

PMS: TASK-393397

## Summary by Sourcery

Move brightness adjustment policy into TreelandColorControl and update tests and build setup accordingly.

Enhancements:
- Embed brightness step and bounds directly in TreelandColorControl and expose a class-scoped adjustedValue helper.

Tests:
- Update brightness policy tests to exercise TreelandColorControl::adjustedValue and adjust test build dependencies.