### PR TITLE
feat: categorize shortcut plugin logs

### DIFF
--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SHORTCUT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Common sources shared between plugin and debug binary
 set(SHORTCUT_COMMON_SOURCES
+    shortcutlogging.cpp
+    shortcutlogging.h
     ${SHORTCUT_SRC_DIR}/core/shortcutmanager.cpp
     ${SHORTCUT_SRC_DIR}/core/keybindingmanager.cpp
     ${SHORTCUT_SRC_DIR}/core/customshortcuttransaction.cpp

--- a/src/plugin-qt/shortcut/plugin.cpp
+++ b/src/plugin-qt/shortcut/plugin.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "pluginshortcutmanager.h"
 
 #include <QDBusConnection>
@@ -20,10 +22,10 @@ static PluginShortcutManager *g_pluginManager = nullptr;
  */
 extern "C" int DSMRegister(const char *name, void *data)
 {
-    qInfo() << "[ShortcutPlugin] DSMRegister called with name:" << name;
+    qCInfo(logShortcut) << "[ShortcutPlugin] DSMRegister called with name:" << name;
 
     if (!data) {
-        qCritical() << "[ShortcutPlugin] Invalid data pointer";
+        qCCritical(logShortcut) << "[ShortcutPlugin] Invalid data pointer";
         return -1;
     }
 
@@ -35,13 +37,13 @@ extern "C" int DSMRegister(const char *name, void *data)
 
     // Initialize plugin
     if (!g_pluginManager->init(connection)) {
-        qCritical() << "[ShortcutPlugin] Failed to initialize plugin";
+        qCCritical(logShortcut) << "[ShortcutPlugin] Failed to initialize plugin";
         delete g_pluginManager;
         g_pluginManager = nullptr;
         return -1;
     }
 
-    qInfo() << "[ShortcutPlugin] Plugin registered successfully";
+    qCInfo(logShortcut) << "[ShortcutPlugin] Plugin registered successfully";
     return 0;
 }
 
@@ -60,7 +62,7 @@ extern "C" int DSMUnRegister(const char *name, void *data)
     Q_UNUSED(name);
     Q_UNUSED(data);
 
-    qInfo() << "[ShortcutPlugin] DSMUnRegister called";
+    qCInfo(logShortcut) << "[ShortcutPlugin] DSMUnRegister called";
 
     if (g_pluginManager) {
         g_pluginManager->cleanup();
@@ -68,6 +70,6 @@ extern "C" int DSMUnRegister(const char *name, void *data)
         g_pluginManager = nullptr;
     }
 
-    qInfo() << "[ShortcutPlugin] Plugin unregistered successfully";
+    qCInfo(logShortcut) << "[ShortcutPlugin] Plugin unregistered successfully";
     return 0;
 }

--- a/src/plugin-qt/shortcut/pluginshortcutmanager.cpp
+++ b/src/plugin-qt/shortcut/pluginshortcutmanager.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "pluginshortcutmanager.h"
 #include "core/shortcutmanager.h"
 #include "core/keybindingmanager.h"
@@ -23,7 +25,7 @@ PluginShortcutManager::~PluginShortcutManager()
 bool PluginShortcutManager::init(QDBusConnection *connection)
 {
     if (!connection) {
-        qCritical() << "[PluginShortcutManager] Invalid DBus connection";
+        qCCritical(logShortcut) << "[PluginShortcutManager] Invalid DBus connection";
         return false;
     }
 
@@ -33,7 +35,7 @@ bool PluginShortcutManager::init(QDBusConnection *connection)
     
     // Initialize ShortcutManager
     if (!m_shortcutManager->init()) {
-        qCritical() << "[PluginShortcutManager] Failed to initialize ShortcutManager";
+        qCCritical(logShortcut) << "[PluginShortcutManager] Failed to initialize ShortcutManager";
         delete m_shortcutManager;
         m_shortcutManager = nullptr;
         return false;
@@ -45,20 +47,20 @@ bool PluginShortcutManager::init(QDBusConnection *connection)
                                                const QString &path,
                                                QObject *object) {
         if (!connection->registerService(service)) {
-            qCritical() << "[PluginShortcutManager] Failed to register service" << service << ":"
+            qCCritical(logShortcut) << "[PluginShortcutManager] Failed to register service" << service << ":"
                         << connection->lastError().message();
             return false;
         }
 
         if (!connection->registerObject(path, object,
                                         QDBusConnection::ExportScriptableContents)) {
-            qCritical() << "[PluginShortcutManager] Failed to register object" << path << ":"
+            qCCritical(logShortcut) << "[PluginShortcutManager] Failed to register object" << path << ":"
                         << connection->lastError().message();
             connection->unregisterService(service);
             return false;
         }
 
-        qInfo() << "[PluginShortcutManager] Registered" << service << "at" << path;
+        qCInfo(logShortcut) << "[PluginShortcutManager] Registered" << service << "at" << path;
         return true;
     };
 
@@ -67,7 +69,7 @@ bool PluginShortcutManager::init(QDBusConnection *connection)
 
     bool keybindingRegistered = false;
     if (!keybindingManager) {
-        qCritical() << "[PluginShortcutManager] KeybindingManager not found";
+        qCCritical(logShortcut) << "[PluginShortcutManager] KeybindingManager not found";
     } else {
         keybindingRegistered = registerEndpoint(
                 QStringLiteral("org.deepin.dde.Keybinding1"),
@@ -77,7 +79,7 @@ bool PluginShortcutManager::init(QDBusConnection *connection)
 
     bool gestureRegistered = false;
     if (!gestureManager) {
-        qWarning() << "[PluginShortcutManager] GestureManager not found";
+        qCWarning(logShortcut) << "[PluginShortcutManager] GestureManager not found";
     } else {
         gestureRegistered = registerEndpoint(
                 QStringLiteral("org.deepin.dde.Gesture1"),
@@ -86,18 +88,18 @@ bool PluginShortcutManager::init(QDBusConnection *connection)
     }
 
     if (!keybindingRegistered && !gestureRegistered) {
-        qCritical() << "[PluginShortcutManager] Failed to register any DBus endpoint";
+        qCCritical(logShortcut) << "[PluginShortcutManager] Failed to register any DBus endpoint";
         return false;
     }
 
-    qInfo() << "[PluginShortcutManager] Plugin initialized successfully";
+    qCInfo(logShortcut) << "[PluginShortcutManager] Plugin initialized successfully";
     return true;
 }
 
 void PluginShortcutManager::cleanup()
 {
     if (m_shortcutManager) {
-        qInfo() << "[PluginShortcutManager] Cleaning up plugin";
+        qCInfo(logShortcut) << "[PluginShortcutManager] Cleaning up plugin";
         
         // Unregister DBus services
         if (m_connection) {

--- a/src/plugin-qt/shortcut/shortcutlogging.cpp
+++ b/src/plugin-qt/shortcut/shortcutlogging.cpp
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "shortcutlogging.h"
+
+Q_LOGGING_CATEGORY(logShortcut, "dde.services.shortcut")

--- a/src/plugin-qt/shortcut/shortcutlogging.h
+++ b/src/plugin-qt/shortcut/shortcutlogging.h
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(logShortcut)

--- a/src/plugin-qt/shortcut/src/backend/specialkeyhandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/specialkeyhandler.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "specialkeyhandler.h"
 
 #include <QDebug>
@@ -23,9 +25,9 @@ SpecialKeyHandler::SpecialKeyHandler(QObject *parent)
     );
 
     if (m_connected) {
-        qInfo() << "SpecialKeyHandler: Connected to org.deepin.dde.KeyEvent1";
+        qCInfo(logShortcut) << "SpecialKeyHandler: Connected to org.deepin.dde.KeyEvent1";
     } else {
-        qWarning() << "SpecialKeyHandler: Failed to connect to org.deepin.dde.KeyEvent1";
+        qCWarning(logShortcut) << "SpecialKeyHandler: Failed to connect to org.deepin.dde.KeyEvent1";
     }
 
     auto *serviceWatcher = new QDBusServiceWatcher(QStringLiteral("org.deepin.dde.KeyEvent1"),
@@ -56,7 +58,7 @@ SpecialKeyHandler::~SpecialKeyHandler()
 bool SpecialKeyHandler::registerKey(const KeyConfig &config)
 {
     if (!m_connected) {
-        qWarning() << "SpecialKeyHandler: Not connected to KeyEvent1 service";
+        qCWarning(logShortcut) << "SpecialKeyHandler: Not connected to KeyEvent1 service";
         return false;
     }
 
@@ -71,7 +73,7 @@ bool SpecialKeyHandler::registerKey(const KeyConfig &config)
 
         uint32_t keycode = parseKeycode(hotkey);
         if (keycode == 0) {
-            qWarning() << "SpecialKeyHandler: Invalid keycode:" << hotkey;
+            qCWarning(logShortcut) << "SpecialKeyHandler: Invalid keycode:" << hotkey;
             continue;
         }
 
@@ -81,7 +83,7 @@ bool SpecialKeyHandler::registerKey(const KeyConfig &config)
         // Check for conflict
         if (m_keycodeBindings.contains(keycode)) {
             const KeyBinding &existing = m_keycodeBindings.value(keycode);
-            qWarning() << "SpecialKeyHandler: Keycode conflict detected:"
+            qCWarning(logShortcut) << "SpecialKeyHandler: Keycode conflict detected:"
                        << keycode << "(" << QString("0x%1").arg(keycode, 0, 16) << ")"
                        << "already registered by" << existing.shortcutId
                        << "- skipping" << config.getId();
@@ -95,7 +97,7 @@ bool SpecialKeyHandler::registerKey(const KeyConfig &config)
         m_keycodeBindings.insert(keycode, binding);
         keycodes.append(keycode);
         
-        qDebug() << "SpecialKeyHandler: Registered keycode" << keycode 
+        qCDebug(logShortcut) << "SpecialKeyHandler: Registered keycode" << keycode
                  << "(" << QString("0x%1").arg(keycode, 0, 16) << ")"
                  << "for" << config.getId();
     }
@@ -121,7 +123,7 @@ bool SpecialKeyHandler::unregisterKey(const QString &shortcutId)
         m_suppressedKeys.remove(keycode);
     }
     
-    qDebug() << "SpecialKeyHandler: Unregistered" << shortcutId;
+    qCDebug(logShortcut) << "SpecialKeyHandler: Unregistered" << shortcutId;
     return true;
 }
 
@@ -226,13 +228,13 @@ void SpecialKeyHandler::onKeyEvent(uint keycode, bool pressed,
             m_keysHeld.insert(keycode);
             
             if (flags & KeyEventFlag::Press) {
-                qDebug() << "SpecialKeyHandler: Key pressed, keycode:" << keycode;
+                qCDebug(logShortcut) << "SpecialKeyHandler: Key pressed, keycode:" << keycode;
                 emit keyActivated(binding.shortcutId);
             }
         } else {
             // Repeat event
             if (flags & KeyEventFlag::Repeat) {
-                qDebug() << "SpecialKeyHandler: Key repeat, keycode:" << keycode;
+                qCDebug(logShortcut) << "SpecialKeyHandler: Key repeat, keycode:" << keycode;
                 emit keyActivated(binding.shortcutId);
             }
         }
@@ -242,7 +244,7 @@ void SpecialKeyHandler::onKeyEvent(uint keycode, bool pressed,
             return;
         
         if (flags & KeyEventFlag::Release) {
-            qDebug() << "SpecialKeyHandler: Key released, keycode:" << keycode;
+            qCDebug(logShortcut) << "SpecialKeyHandler: Key released, keycode:" << keycode;
             emit keyActivated(binding.shortcutId);
         }
     }

--- a/src/plugin-qt/shortcut/src/backend/wayland/treelandshortcutwrapper.cpp
+++ b/src/plugin-qt/shortcut/src/backend/wayland/treelandshortcutwrapper.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "treelandshortcutwrapper.h"
 
 #include <QDebug>
@@ -52,12 +54,12 @@ TreelandShortcutWrapper::TreelandShortcutWrapper(QObject *parent)
 
     connect(this, &TreelandShortcutWrapper::activeChanged, this, [this]() {
         if (isActive()) {
-            qDebug() << "TreelandShortcutManager protocol is now active, acquiring...";
+            qCDebug(logShortcut) << "TreelandShortcutManager protocol is now active, acquiring...";
             acquire();
             m_boundObject = object();  // Save bound object for session recovery check
             emit ready();  // Emit signal directly since signal is connected before init() is called
         } else {
-            qWarning() << "TreelandShortcutManager protocol is now inactive!";
+            qCWarning(logShortcut) << "TreelandShortcutManager protocol is now inactive!";
             m_boundObject = nullptr;
             emit protocolInactive();
         }
@@ -116,7 +118,7 @@ bool TreelandShortcutWrapper::unbind(const QString &name)
 
     // Check if object changed (session recovery scenario)
     if (object() != m_boundObject) {
-        qWarning() << "TreelandShortcutWrapper::unbind: object changed, skip unbind for" << name;
+        qCWarning(logShortcut) << "TreelandShortcutWrapper::unbind: object changed, skip unbind for" << name;
         return false;
     }
 
@@ -166,12 +168,12 @@ bool TreelandShortcutWrapper::commitAndWait(int timeoutMs)
         loop.quit();
         success = status;
         responded = true;
-        qDebug() << "TreelandShortcutWrapper::commitAndWait response:" << status;
+        qCDebug(logShortcut) << "TreelandShortcutWrapper::commitAndWait response:" << status;
     }, Qt::SingleShotConnection);
 
     QTimer::singleShot(timeoutMs, &loop, [&]() {
         if (!responded) {
-            qWarning() << "TreelandShortcutWrapper::commitAndWait timeout after" << timeoutMs << "ms";
+            qCWarning(logShortcut) << "TreelandShortcutWrapper::commitAndWait timeout after" << timeoutMs << "ms";
             loop.quit();
         }
     });
@@ -184,7 +186,7 @@ bool TreelandShortcutWrapper::commitAndWait(int timeoutMs)
 
 void TreelandShortcutWrapper::treeland_shortcut_manager_v2_activated(const QString &name, uint32_t flags)
 {
-    qDebug() << "Treeland Shortcut Manager Activated:" << name << "flags:" << flags;
+    qCDebug(logShortcut) << "Treeland Shortcut Manager Activated:" << name << "flags:" << flags;
     emit activated(name, flags);
 }
 
@@ -195,7 +197,7 @@ void TreelandShortcutWrapper::treeland_shortcut_manager_v2_commit_success()
 
 void TreelandShortcutWrapper::treeland_shortcut_manager_v2_commit_failure(const QString &name, uint32_t error)
 {
-    qWarning() << "Treeland Shortcut Manager Commit Failed:" << name
+    qCWarning(logShortcut) << "Treeland Shortcut Manager Commit Failed:" << name
                << "Error:" << error << bindErrorName(error);
     emit commitStatus(false);
 }

--- a/src/plugin-qt/shortcut/src/backend/wayland/waylandgesturehandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/wayland/waylandgesturehandler.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "waylandgesturehandler.h"
 #include "core/shortcutconfig.h"
 #include "treelandshortcutwrapper.h"
@@ -14,7 +16,7 @@ WaylandGestureHandler::WaylandGestureHandler(TreelandShortcutWrapper *wrapper, Q
 {
     connect(m_wrapper, &TreelandShortcutWrapper::activated, this, &WaylandGestureHandler::onActivated);
     connect(m_wrapper, &TreelandShortcutWrapper::protocolInactive, this, [this]() {
-        qWarning() << "WaylandGestureHandler: Protocol inactive, clearing all bindings";
+        qCWarning(logShortcut) << "WaylandGestureHandler: Protocol inactive, clearing all bindings";
         m_bindings.clear();
     });
 }
@@ -52,7 +54,7 @@ bool WaylandGestureHandler::registerGesture(const GestureConfig &config)
     if (success) {
         m_bindings.append(name);
     } else {
-        qWarning() << "Failed to bind gesture for" << config.getId();
+        qCWarning(logShortcut) << "Failed to bind gesture for" << config.getId();
     }
 
     return success;
@@ -78,7 +80,7 @@ bool WaylandGestureHandler::commitSync()
 {
     bool success = m_wrapper->commitAndWait();
     if (!success) {
-        qWarning() << "WaylandGestureHandler::commitSync failed";
+        qCWarning(logShortcut) << "WaylandGestureHandler::commitSync failed";
     }
 
     return success;
@@ -90,6 +92,6 @@ void WaylandGestureHandler::onActivated(const QString &name, uint32_t flags)
     // Forward the activation signal to GestureHandler
     if (!m_bindings.contains(name)) return;
 
-    qDebug() << "WaylandGestureHandler::onActivated name:" << name << "flags:" << flags;
+    qCDebug(logShortcut) << "WaylandGestureHandler::onActivated name:" << name << "flags:" << flags;
     emit activated(name);
 }

--- a/src/plugin-qt/shortcut/src/backend/wayland/waylandkeyhandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/wayland/waylandkeyhandler.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "waylandkeyhandler.h"
 #include "core/triggeractioncatalog.h"
 #include "core/shortcutconfig.h"
@@ -19,7 +21,7 @@ WaylandKeyHandler::WaylandKeyHandler(TreelandShortcutWrapper *wrapper, QObject *
 {
     connect(m_wrapper, &TreelandShortcutWrapper::activated, this, &WaylandKeyHandler::onActivated);
     connect(m_wrapper, &TreelandShortcutWrapper::protocolInactive, this, [this]() {
-        qWarning() << "WaylandKeyHandler: Protocol inactive, clearing all bindings";
+        qCWarning(logShortcut) << "WaylandKeyHandler: Protocol inactive, clearing all bindings";
         m_nameToId.clear();
         m_idToNames.clear();
     });
@@ -55,7 +57,7 @@ bool WaylandKeyHandler::registerKey(const KeyConfig &config)
         if (!treelandAction) {
             // TODO: register this action after Treeland adds the corresponding
             // compositor protocol support.  Keep the config visible meanwhile.
-            qInfo() << "WaylandKeyHandler: compositor action is not supported by Treeland:"
+            qCInfo(logShortcut) << "WaylandKeyHandler: compositor action is not supported by Treeland:"
                     << config.getId() << config.triggerValue.value(0);
             return false;
         }
@@ -67,7 +69,7 @@ bool WaylandKeyHandler::registerKey(const KeyConfig &config)
 
     for (const QString &hotkey : config.hotkeys) {
         if (isLockKey(hotkey)) {
-            qDebug() << "Skipping lock key registration on Wayland:" << hotkey
+            qCDebug(logShortcut) << "Skipping lock key registration on Wayland:" << hotkey
                      << "for" << config.getId();
             continue;
         }
@@ -81,7 +83,7 @@ bool WaylandKeyHandler::registerKey(const KeyConfig &config)
             bindings.append(name);
         } else {
             allSuccess = false;
-            qWarning() << "Failed to bind key:" << hotkey << "for" << config.getId();
+            qCWarning(logShortcut) << "Failed to bind key:" << hotkey << "for" << config.getId();
         }
     }
 
@@ -116,7 +118,7 @@ bool WaylandKeyHandler::commitSync()
 {
     bool success = m_wrapper->commitAndWait();
     if (!success) {
-        qWarning() << "WaylandKeyHandler::commitSync failed";
+        qCWarning(logShortcut) << "WaylandKeyHandler::commitSync failed";
     }
 
     return success;
@@ -128,7 +130,7 @@ void WaylandKeyHandler::onActivated(const QString &name, uint32_t flags)
     // Forward the activation signal to KeybindingManager
     if (m_nameToId.contains(name)) {
         QString id = m_nameToId.value(name);
-        qDebug() << "WaylandKeyHandler::onActivated name:" << name << "id:" << id
+        qCDebug(logShortcut) << "WaylandKeyHandler::onActivated name:" << name << "id:" << id
                  << "flags:" << flags;
         
         emit keyActivated(id);

--- a/src/plugin-qt/shortcut/src/backend/x11/modifierkeymonitor.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/modifierkeymonitor.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "modifierkeymonitor.h"
 
 #include <QDebug>
@@ -56,7 +58,7 @@ bool ModifierKeyMonitor::initializeRawEvents()
 {
     m_eventConnection = xcb_connect(nullptr, nullptr);
     if (!m_eventConnection || xcb_connection_has_error(m_eventConnection)) {
-        qWarning() << "ModifierMonitor: Failed to connect to X server";
+        qCWarning(logShortcut) << "ModifierMonitor: Failed to connect to X server";
         return false;
     }
 
@@ -69,7 +71,7 @@ bool ModifierKeyMonitor::initializeRawEvents()
     m_keySymbols = xcb_key_symbols_alloc(m_eventConnection);
     const xcb_query_extension_reply_t *extension = xcb_get_extension_data(m_eventConnection, &xcb_input_id);
     if (!m_screen || !m_keySymbols || !extension || !extension->present) {
-        qWarning() << "ModifierMonitor: XInput2 is unavailable";
+        qCWarning(logShortcut) << "ModifierMonitor: XInput2 is unavailable";
         return false;
     }
     m_inputOpcode = extension->major_opcode;
@@ -79,7 +81,7 @@ bool ModifierKeyMonitor::initializeRawEvents()
     xcb_input_xi_query_version_reply_t *versionReply =
             xcb_input_xi_query_version_reply(m_eventConnection, versionCookie, &versionError);
     if (!versionReply || versionError) {
-        qWarning() << "ModifierMonitor: XInput2 version negotiation failed";
+        qCWarning(logShortcut) << "ModifierMonitor: XInput2 version negotiation failed";
         free(versionReply);
         free(versionError);
         return false;
@@ -102,7 +104,7 @@ bool ModifierKeyMonitor::initializeRawEvents()
                 m_eventConnection, rootWindow, 1, &eventMask.header);
         xcb_generic_error_t *selectError = xcb_request_check(m_eventConnection, selectCookie);
         if (selectError) {
-            qWarning() << "ModifierMonitor: Failed to select XInput2 raw events:"
+            qCWarning(logShortcut) << "ModifierMonitor: Failed to select XInput2 raw events:"
                        << selectError->error_code << "on root" << rootWindow;
             free(selectError);
             return false;
@@ -189,7 +191,7 @@ void ModifierKeyMonitor::handleEvents()
         if (parseModifierKeyEvent(pendingEvent, pressed, keycode) && pressed
                 && pressIndex < statesBeforePresses.size()) {
             if (m_state.reconcileAtEventBoundary(statesBeforePresses.at(pressIndex))) {
-                qInfo() << "ModifierMonitor: recovered stale state before key press"
+                qCInfo(logShortcut) << "ModifierMonitor: recovered stale state before key press"
                         << int(keycode);
             }
             ++pressIndex;
@@ -200,7 +202,7 @@ void ModifierKeyMonitor::handleEvents()
 
     if (physicallyPressed && !mappingChanged
             && m_state.reconcileAtEventBoundary(physicallyPressed.value())) {
-        qInfo() << "ModifierMonitor: recovered stale state after event batch";
+        qCInfo(logShortcut) << "ModifierMonitor: recovered stale state after event batch";
     }
 }
 

--- a/src/plugin-qt/shortcut/src/backend/x11/systemgestureproxy.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/systemgestureproxy.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "systemgestureproxy.h"
 
 #include <QDBusConnection>
@@ -92,9 +94,9 @@ bool SystemGestureProxy::connectEventSignal()
             QLatin1String(Service), QLatin1String(Path), QLatin1String(Interface),
             QStringLiteral("SwipeStop"), this, SLOT(onSwipeStopped(int)));
     if (!m_connected)
-        qWarning() << "SystemGestureProxy: failed to subscribe to system gesture events";
+        qCWarning(logShortcut) << "SystemGestureProxy: failed to subscribe to system gesture events";
     if (!doubleClickConnected || !movingConnected || !stoppedConnected)
-        qWarning() << "SystemGestureProxy: failed to subscribe to window-move gesture events";
+        qCWarning(logShortcut) << "SystemGestureProxy: failed to subscribe to window-move gesture events";
     return m_connected;
 }
 

--- a/src/plugin-qt/shortcut/src/backend/x11/x11gestureactionexecutor.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11gestureactionexecutor.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "x11gestureactionexecutor.h"
 #include "core/gestureactioncatalog.h"
 
@@ -65,7 +67,7 @@ bool X11GestureActionExecutor::execute(const GestureConfig &config)
     const QString actionValue = GestureActionCatalog::idString(actionId);
     const bool success = executeAction(actionId, actionValue);
     if (!success) {
-        qWarning() << "X11GestureActionExecutor: action failed: gesture" << config.getId()
+        qCWarning(logShortcut) << "X11GestureActionExecutor: action failed: gesture" << config.getId()
                    << "configured action" << config.triggerValue.value(0)
                    << "resolved action" << int(actionId);
     }
@@ -81,7 +83,7 @@ bool X11GestureActionExecutor::execute(const KeyConfig &config)
     const auto actionId = ok ? static_cast<GestureActionId>(value) : GestureActionId::Invalid;
     const bool success = executeAction(actionId, config.getId());
     if (!success)
-        qWarning() << "X11GestureActionExecutor: shortcut action failed:" << config.getId()
+        qCWarning(logShortcut) << "X11GestureActionExecutor: shortcut action failed:" << config.getId()
                    << value;
     return success;
 }
@@ -181,7 +183,7 @@ bool X11GestureActionExecutor::beginWindowMove()
             return;
 
         if (reply.isError()) {
-            qWarning() << "X11GestureActionExecutor: window move begin failed:"
+            qCWarning(logShortcut) << "X11GestureActionExecutor: window move begin failed:"
                        << reply.error().message();
             clearWindowMove();
             return;
@@ -244,7 +246,7 @@ bool X11GestureActionExecutor::sendWindowMoveUpdate()
 
         m_windowMoveUpdatePending = false;
         if (reply.isError()) {
-            qWarning() << "X11GestureActionExecutor: window move update failed:"
+            qCWarning(logShortcut) << "X11GestureActionExecutor: window move update failed:"
                        << reply.error().message();
             clearWindowMove();
             return;
@@ -280,7 +282,7 @@ bool X11GestureActionExecutor::clearWindowMove()
             [this](QDBusPendingCallWatcher *finishedWatcher) {
         const QDBusPendingReply<> reply = *finishedWatcher;
         if (reply.isError()) {
-            qWarning() << "X11GestureActionExecutor: window move end failed:"
+            qCWarning(logShortcut) << "X11GestureActionExecutor: window move end failed:"
                        << reply.error().message();
         }
         finishedWatcher->deleteLater();
@@ -327,7 +329,7 @@ void X11GestureActionExecutor::updateMultitaskVisible()
         const QDBusPendingReply<bool> reply = *finishedWatcher;
         finishedWatcher->deleteLater();
         if (reply.isError()) {
-            qWarning() << "X11GestureActionExecutor:" << m_multitaskActionId
+            qCWarning(logShortcut) << "X11GestureActionExecutor:" << m_multitaskActionId
                        << "failed to query multitask state:" << reply.error().message();
             m_multitaskUpdatePending = false;
             if (queryGeneration != m_multitaskTargetGeneration)
@@ -336,7 +338,7 @@ void X11GestureActionExecutor::updateMultitaskVisible()
         }
 
         if (reply.value() == m_multitaskTargetVisible) {
-            qDebug() << "X11GestureActionExecutor: action completed:" << m_multitaskActionId;
+            qCDebug(logShortcut) << "X11GestureActionExecutor: action completed:" << m_multitaskActionId;
             m_multitaskUpdatePending = false;
             return;
         }
@@ -356,10 +358,10 @@ void X11GestureActionExecutor::updateMultitaskVisible()
                         QDBusPendingCallWatcher *finishedToggle) {
             const QDBusPendingReply<> toggleReply = *finishedToggle;
             if (toggleReply.isError()) {
-                qWarning() << "X11GestureActionExecutor:" << actionId
+                qCWarning(logShortcut) << "X11GestureActionExecutor:" << actionId
                            << "failed to update multitask state:" << toggleReply.error().message();
             } else {
-                qDebug() << "X11GestureActionExecutor: action completed:" << actionId;
+                qCDebug(logShortcut) << "X11GestureActionExecutor: action completed:" << actionId;
             }
             finishedToggle->deleteLater();
             m_multitaskUpdatePending = false;
@@ -406,10 +408,10 @@ bool X11GestureActionExecutor::call(const QString &service, const QString &path,
             [context](QDBusPendingCallWatcher *finishedWatcher) {
         const QDBusPendingReply<> reply = *finishedWatcher;
         if (reply.isError()) {
-            qWarning() << "X11GestureActionExecutor: action failed:" << context
+            qCWarning(logShortcut) << "X11GestureActionExecutor: action failed:" << context
                        << reply.error().message();
         } else {
-            qDebug() << "X11GestureActionExecutor: action completed:" << context;
+            qCDebug(logShortcut) << "X11GestureActionExecutor: action completed:" << context;
         }
         finishedWatcher->deleteLater();
     });

--- a/src/plugin-qt/shortcut/src/backend/x11/x11keyhandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11keyhandler.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "x11keyhandler.h"
 #include "modifierkeymonitor.h"
 #include "core/triggeractioncatalog.h"
@@ -122,13 +124,13 @@ X11KeyHandler::X11KeyHandler(QObject *parent)
 
     m_display = XOpenDisplay(nullptr);
     if (!m_display) {
-        qCritical() << "X11KeyHandler: Failed to connect to X11 server";
+        qCCritical(logShortcut) << "X11KeyHandler: Failed to connect to X11 server";
         return;
     }
     XSetEventQueueOwner(m_display, XCBOwnsEventQueue);
     m_connection = XGetXCBConnection(m_display);
     if (!m_connection || xcb_connection_has_error(m_connection)) {
-        qCritical() << "X11KeyHandler: Failed to obtain XCB connection";
+        qCCritical(logShortcut) << "X11KeyHandler: Failed to obtain XCB connection";
         return;
     }
 
@@ -139,13 +141,13 @@ X11KeyHandler::X11KeyHandler(QObject *parent)
         xcb_screen_next(&iter);
     }
     if (m_rootWindows.isEmpty()) {
-        qCritical() << "X11KeyHandler: X11 server has no screens";
+        qCCritical(logShortcut) << "X11KeyHandler: X11 server has no screens";
         return;
     }
 
     m_keySymbols = xcb_key_symbols_alloc(m_connection);
     if (!m_keySymbols) {
-        qCritical() << "X11KeyHandler: Failed to allocate keyboard symbols";
+        qCCritical(logShortcut) << "X11KeyHandler: Failed to allocate keyboard symbols";
         return;
     }
     refreshModifierMasks();
@@ -207,7 +209,7 @@ bool X11KeyHandler::beginCapture(uint timeoutMs, const QString &owner)
     xcb_grab_keyboard_reply_t *keyboardReply =
             xcb_grab_keyboard_reply(m_connection, keyboardCookie, nullptr);
     if (!keyboardReply || keyboardReply->status != XCB_GRAB_STATUS_SUCCESS) {
-        qWarning() << "X11KeyHandler: failed to grab keyboard for shortcut capture";
+        qCWarning(logShortcut) << "X11KeyHandler: failed to grab keyboard for shortcut capture";
         free(keyboardReply);
         return false;
     }
@@ -221,7 +223,7 @@ bool X11KeyHandler::beginCapture(uint timeoutMs, const QString &owner)
     xcb_grab_pointer_reply_t *pointerReply =
             xcb_grab_pointer_reply(m_connection, pointerCookie, nullptr);
     if (!pointerReply || pointerReply->status != XCB_GRAB_STATUS_SUCCESS) {
-        qWarning() << "X11KeyHandler: failed to grab pointer for shortcut capture";
+        qCWarning(logShortcut) << "X11KeyHandler: failed to grab pointer for shortcut capture";
         free(pointerReply);
         xcb_ungrab_keyboard(m_connection, XCB_CURRENT_TIME);
         xcb_flush(m_connection);
@@ -290,7 +292,7 @@ void X11KeyHandler::finishCapture(bool notify)
 bool X11KeyHandler::registerKey(const KeyConfig &config)
 {
     if (!isAvailable()) {
-        qCritical() << "X11KeyHandler: XCB connection not available, cannot register key:" << config.getId();
+        qCCritical(logShortcut) << "X11KeyHandler: XCB connection not available, cannot register key:" << config.getId();
         return false;
     }
 
@@ -304,7 +306,7 @@ bool X11KeyHandler::registerKey(const KeyConfig &config)
         if (!setWmShortcut(delegatedWmId, config.hotkeys))
             return false;
         m_wmShortcutIds.insert(config.getId(), delegatedWmId);
-        qInfo() << "X11KeyHandler: delegated shortcut to KWin:"
+        qCInfo(logShortcut) << "X11KeyHandler: delegated shortcut to KWin:"
                 << config.getId() << delegatedWmId << config.hotkeys;
         return true;
     }
@@ -334,12 +336,12 @@ bool X11KeyHandler::registerKey(const KeyConfig &config)
                     resolution == HotkeyResolution::UnavailableInKeymap
                     && candidate.requirement == PhysicalKeyAlias::X11CandidateRequirement::IfAvailable;
             if (unavailableAlias) {
-                qInfo() << "X11KeyHandler: Physical alias is unavailable in the current keymap:"
+                qCInfo(logShortcut) << "X11KeyHandler: Physical alias is unavailable in the current keymap:"
                         << xkbHotkey;
                 continue;
             }
 
-            qWarning() << "X11KeyHandler: Failed to resolve hotkey:" << xkbHotkey
+            qCWarning(logShortcut) << "X11KeyHandler: Failed to resolve hotkey:" << xkbHotkey
                        << (resolution == HotkeyResolution::InvalidSpecification
                                    ? "invalid specification"
                                    : "unavailable in current keymap");
@@ -352,7 +354,7 @@ bool X11KeyHandler::registerKey(const KeyConfig &config)
                 && isStandaloneModifierKey(hotkey.keysym, hotkey.modifierCombinations.constFirst());
         if (isStandaloneModifier
                 && (!m_modifierMonitor || !m_modifierMonitor->isAvailable())) {
-            qWarning() << "X11KeyHandler: Standalone modifier monitor is unavailable:" << xkbHotkey;
+            qCWarning(logShortcut) << "X11KeyHandler: Standalone modifier monitor is unavailable:" << xkbHotkey;
             allSuccess = false;
             break;
         }
@@ -366,7 +368,7 @@ bool X11KeyHandler::registerKey(const KeyConfig &config)
 
                 if (!isStandaloneModifier && !grabKey(keycode, modifiers)) {
                     candidateFailed = true;
-                    qWarning() << "X11KeyHandler: Failed to grab hotkey:" << xkbHotkey
+                    qCWarning(logShortcut) << "X11KeyHandler: Failed to grab hotkey:" << xkbHotkey
                                << "keycode:" << keycode << "modifiers:" << Qt::hex << modifiers;
                     break;
                 }
@@ -386,7 +388,7 @@ bool X11KeyHandler::registerKey(const KeyConfig &config)
     }
 
     if (!allSuccess && !grabbed.isEmpty()) {
-        qWarning() << "X11KeyHandler: Partial registration failure for" << config.getId()
+        qCWarning(logShortcut) << "X11KeyHandler: Partial registration failure for" << config.getId()
                    << "- rolling back" << grabbed.size() << "successful grabs";
         for (uint32_t key : std::as_const(grabbed)) {
             const xcb_keycode_t keycode = key & 0xFFFF;
@@ -478,7 +480,7 @@ bool X11KeyHandler::setWmShortcut(const QString &wmShortcutId, const QStringList
         m_wmSetAccelSignature = WmSetAccelSignature::DataOnly;
     }
     if (!reply.isValid() || !reply.value()) {
-        qWarning() << "X11KeyHandler: failed to set KWin shortcut:"
+        qCWarning(logShortcut) << "X11KeyHandler: failed to set KWin shortcut:"
                    << wmShortcutId << hotkeys << reply.error().message();
         return false;
     }
@@ -502,7 +504,7 @@ bool X11KeyHandler::grabKey(xcb_keycode_t keycode, uint16_t modifiers)
 
             xcb_generic_error_t *error = xcb_request_check(m_connection, cookie);
             if (error) {
-                qWarning() << "Failed to grab key" << keycode << "with modifiers" << Qt::hex << modifiers
+                qCWarning(logShortcut) << "Failed to grab key" << keycode << "with modifiers" << Qt::hex << modifiers
                           << "on root" << rootWindow << "Error code:" << error->error_code;
                 free(error);
                 hasError = true;
@@ -856,7 +858,7 @@ void X11KeyHandler::enableDetectableAutoRepeat()
             && XkbSetDetectableAutoRepeat(m_display, True, &supported)
             && supported;
     if (!m_detectableAutoRepeat)
-        qWarning() << "X11KeyHandler: falling back to Release/Press autorepeat detection";
+        qCWarning(logShortcut) << "X11KeyHandler: falling back to Release/Press autorepeat detection";
 }
 
 void X11KeyHandler::handleKeyPress(const xcb_key_press_event_t *event)
@@ -1002,7 +1004,7 @@ void X11KeyHandler::setCapsLockState(bool on)
     xcb_keycode_t *keycodes = xcb_key_symbols_get_keycode(m_keySymbols, XK_Caps_Lock);
     if (!keycodes || keycodes[0] == XCB_NO_SYMBOL) {
         if (keycodes) free(keycodes);
-        qWarning() << "Failed to get CapsLock keycode";
+        qCWarning(logShortcut) << "Failed to get CapsLock keycode";
         return;
     }
     
@@ -1027,7 +1029,7 @@ void X11KeyHandler::setNumLockState(bool on)
     xcb_keycode_t *keycodes = xcb_key_symbols_get_keycode(m_keySymbols, XK_Num_Lock);
     if (!keycodes || keycodes[0] == XCB_NO_SYMBOL) {
         if (keycodes) free(keycodes);
-        qWarning() << "Failed to get NumLock keycode";
+        qCWarning(logShortcut) << "Failed to get NumLock keycode";
         return;
     }
     

--- a/src/plugin-qt/shortcut/src/config/configloader.cpp
+++ b/src/plugin-qt/shortcut/src/config/configloader.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "configloader.h"
 #include "core/commandlineparser.h"
 
@@ -66,7 +68,7 @@ ConfigLoader::ConfigLoader(QObject *parent)
 void ConfigLoader::scanForConfigs()
 {
     QSet<QString> foundSubPaths = discoverSubPaths();
-    qInfo() << "ConfigLoader: Found subpaths:" << foundSubPaths;
+    qCInfo(logShortcut) << "ConfigLoader: Found subpaths:" << foundSubPaths;
 
     for (const QString &subPath : foundSubPaths) {
         if (!m_loadedSubPaths.contains(subPath)) {
@@ -77,14 +79,14 @@ void ConfigLoader::scanForConfigs()
 
 void ConfigLoader::reload()
 {
-    qInfo() << "ConfigLoader reloading (Smart Diff INI-only)...";
+    qCInfo(logShortcut) << "ConfigLoader reloading (Smart Diff INI-only)...";
     QSet<QString> currentSubPaths = discoverSubPaths();
 
     // Compare with existing configs (Remove Stale)
     QList<QString> existingSubPaths(m_loadedSubPaths.constBegin(), m_loadedSubPaths.constEnd());
     for (const QString &subPath : existingSubPaths) {
         if (!currentSubPaths.contains(subPath)) {
-            qInfo() << "Config removed:" << subPath;
+            qCInfo(logShortcut) << "Config removed:" << subPath;
             m_loadedSubPaths.remove(subPath);
 
             m_keys.erase(std::remove_if(m_keys.begin(), m_keys.end(),
@@ -106,7 +108,7 @@ void ConfigLoader::reload()
     // Add New
     for (const QString &subPath : currentSubPaths) {
         if (!m_loadedSubPaths.contains(subPath)) {
-            qInfo() << "Config added:" << subPath;
+            qCInfo(logShortcut) << "Config added:" << subPath;
             loadConfig(subPath, true);
         }
     }
@@ -143,7 +145,7 @@ void ConfigLoader::resetHotkeys(const QStringList &ids)
         if (config && config->isValid() && !config->isReadOnly(QStringLiteral("hotkeys"))) {
             config->reset("hotkeys");
         } else {
-            qWarning() << "ConfigLoader: hotkeys can not be reset:" << id;
+            qCWarning(logShortcut) << "ConfigLoader: hotkeys can not be reset:" << id;
         }
     }
 }
@@ -153,7 +155,7 @@ bool ConfigLoader::reloadKeyConfig(const QString &id, KeyConfig *result)
     const QString normalizedId = CustomShortcutStore::normalizeSubPath(id);
     DConfig *config = m_configs.value(normalizedId);
     if (!config || !config->isValid()) {
-        qWarning() << "ConfigLoader: key config can not be reloaded:" << id;
+        qCWarning(logShortcut) << "ConfigLoader: key config can not be reloaded:" << id;
         return false;
     }
 
@@ -174,14 +176,14 @@ bool ConfigLoader::updateValue(const QString &id, const QString &key, const QVar
 {
     DConfig *config = m_configs.value(id);
     if (!config || !config->isValid() || config->isReadOnly(key)) {
-        qWarning() << "ConfigLoader: config not found or can not be changed:" << id << key << value;
+        qCWarning(logShortcut) << "ConfigLoader: config not found or can not be changed:" << id << key << value;
         return false;
     }
 
     config->setValue(key, value);
     const QVariant actualValue = config->value(key);
     if (!configValuesEqual(actualValue, value)) {
-        qWarning() << "ConfigLoader: value verification failed:" << id << key
+        qCWarning(logShortcut) << "ConfigLoader: value verification failed:" << id << key
                    << "expected:" << value << "actual:" << actualValue;
         return false;
     }
@@ -223,7 +225,7 @@ QSet<QString> ConfigLoader::scanIniSubPaths(const QString &dirPath)
         QString fullPath = regDir.absoluteFilePath(iniFile);
         QFile file(fullPath);
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            qWarning() << "ConfigLoader: Failed to open" << fullPath;
+            qCWarning(logShortcut) << "ConfigLoader: Failed to open" << fullPath;
             continue;
         }
         QString content = QString::fromUtf8(file.readAll());
@@ -234,7 +236,7 @@ QSet<QString> ConfigLoader::scanIniSubPaths(const QString &dirPath)
         QTemporaryFile tmpFile;
         tmpFile.setAutoRemove(true);
         if (!tmpFile.open()) {
-            qWarning() << "ConfigLoader: Failed to create temp file for" << fullPath;
+            qCWarning(logShortcut) << "ConfigLoader: Failed to create temp file for" << fullPath;
             continue;
         }
         tmpFile.write(content.toUtf8());
@@ -258,7 +260,7 @@ QSet<QString> ConfigLoader::scanIniSubPaths(const QString &dirPath)
 
         settings.endGroup();
 
-        qDebug() << "ConfigLoader: File:" << fullPath << "Parsed" << subPaths.size() << "subpaths";
+        qCDebug(logShortcut) << "ConfigLoader: File:" << fullPath << "Parsed" << subPaths.size() << "subpaths";
 
         if (!subPaths.isEmpty()) {
             for (const QString &subPath : subPaths) {
@@ -280,7 +282,7 @@ bool ConfigLoader::saveCustomShortcut(const KeyConfig &config)
         if (!customDconfig)
             return false;
         if (!customDconfig->isValid()) {
-            qWarning() << "ConfigLoader: failed to create custom shortcut DConfig:" << subPath;
+            qCWarning(logShortcut) << "ConfigLoader: failed to create custom shortcut DConfig:" << subPath;
             delete customDconfig;
             return false;
         }
@@ -309,12 +311,12 @@ bool ConfigLoader::saveCustomShortcut(const KeyConfig &config)
     if (!m_configs.contains(subPath)) {
         connect(customDconfig, &DConfig::valueChanged, this, [this, subPath, customDconfig](const QString &key) {
             if (!customDconfig->isValid() || !m_configs.contains(subPath)) {
-                qWarning() << "DConfig invalid or not found:" << subPath;
+                qCWarning(logShortcut) << "DConfig invalid or not found:" << subPath;
                 return;
             }
 
             KeyConfig updatedConfig = parseKeyConfig(customDconfig);
-            qDebug() << "DConfig value changed:" << subPath << key;
+            qCDebug(logShortcut) << "DConfig value changed:" << subPath << key;
             auto existing = std::find_if(m_keys.begin(), m_keys.end(),
                                          [&](const KeyConfig &item) { return item.subPath == subPath; });
             if (existing != m_keys.end()) {
@@ -335,7 +337,7 @@ bool ConfigLoader::updateCustomShortcut(const KeyConfig &config)
     const QString subPath = CustomShortcutStore::normalizeSubPath(config.subPath);
     DConfig *customDconfig = m_configs.value(subPath);
     if (!customDconfig) {
-        qWarning() << "ConfigLoader: custom shortcut config not found for update:" << subPath;
+        qCWarning(logShortcut) << "ConfigLoader: custom shortcut config not found for update:" << subPath;
         return false;
     }
 
@@ -364,12 +366,12 @@ bool ConfigLoader::removeCustomShortcut(const QString &subPath)
 
     DConfig *config = m_configs.value(normalized);
     if (!config || !config->isValid()) {
-        qWarning() << "ConfigLoader: custom shortcut config not found for removal:" << subPath;
+        qCWarning(logShortcut) << "ConfigLoader: custom shortcut config not found for removal:" << subPath;
         return false;
     }
 
     if (!m_customStore.removeSubPath(normalized)) {
-        qWarning() << "ConfigLoader: failed to remove custom shortcut subPath:" << normalized;
+        qCWarning(logShortcut) << "ConfigLoader: failed to remove custom shortcut subPath:" << normalized;
         return false;
     }
     m_customShortcutSubPaths.removeAll(normalized);
@@ -391,20 +393,20 @@ bool ConfigLoader::removeCustomShortcut(const QString &subPath)
 
 void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
 {
-    qDebug() << "Loading config from:" << subPath;
+    qCDebug(logShortcut) << "Loading config from:" << subPath;
     // Check if it's a shortcut or gesture config
     bool isKey = subPath.contains(".shortcut");
     bool isGesture = subPath.contains(".gesture");
 
     if (!isKey && !isGesture) {
-        qWarning() << "Skipping" << subPath << "(not shortcut or gesture)";
+        qCWarning(logShortcut) << "Skipping" << subPath << "(not shortcut or gesture)";
         return;
     }
 
     DConfig *config = createDConfig(isKey ? CONFIG_NAME_SHORTCUT : CONFIG_NAME_GESTURE,
                                     subPath, this);
     if (!config->isValid()) {
-        qWarning() << "Failed to create DConfig for" << subPath;
+        qCWarning(logShortcut) << "Failed to create DConfig for" << subPath;
         delete config;
         return;
     }
@@ -419,7 +421,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
             // Most commonly invalid configs are shipped-disabled hardware keys
             // (e.g. wlan with enabled=false). Remember the subPath so reload()
             // doesn't re-attempt and log this every dpkg trigger.
-            qWarning() << "Skipping invalid or disabled KeyConfig:" << subPath
+            qCWarning(logShortcut) << "Skipping invalid or disabled KeyConfig:" << subPath
                        << "(enabled=" << keyConfig.enabled
                        << ", appId set=" << !keyConfig.appId.isEmpty()
                        << ", displayName set=" << !keyConfig.displayName.isEmpty()
@@ -430,7 +432,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
         }
 
         configCanNotChanged = !keyConfig.modifiable;
-        qDebug() << "Parsed KeyConfig:" << keyConfig.appId << keyConfig.hotkeys << subPath;
+        qCDebug(logShortcut) << "Parsed KeyConfig:" << keyConfig.appId << keyConfig.hotkeys << subPath;
         m_loadedSubPaths.insert(subPath);
         m_keys.append(keyConfig);
 
@@ -440,7 +442,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
     } else {
         GestureConfig gestureConfig = parseGestureConfig(config);
         if (!gestureConfig.isValid()) {
-            qWarning() << "Skipping invalid or disabled GestureConfig:" << subPath
+            qCWarning(logShortcut) << "Skipping invalid or disabled GestureConfig:" << subPath
                        << "(enabled=" << gestureConfig.enabled
                        << ", appId set=" << !gestureConfig.appId.isEmpty()
                        << ", displayName set=" << !gestureConfig.displayName.isEmpty()
@@ -452,7 +454,7 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
         }
 
         configCanNotChanged = !gestureConfig.modifiable;
-        qDebug() << "Parsed GestureConfig:" << gestureConfig.appId << subPath;
+        qCDebug(logShortcut) << "Parsed GestureConfig:" << gestureConfig.appId << subPath;
         m_loadedSubPaths.insert(subPath);
         m_gestures.append(gestureConfig);
 
@@ -466,11 +468,11 @@ void ConfigLoader::loadConfig(const QString &subPath, bool newOne)
     } else {
         connect(config, &DConfig::valueChanged, this, [this, subPath, isKey, config](const QString &key) {
             if (!config->isValid() || !m_configs.contains(subPath)) {
-                qWarning() << "DConfig invalid or not found:" << subPath;
+                qCWarning(logShortcut) << "DConfig invalid or not found:" << subPath;
                 return;
             }
 
-            qDebug() << "DConfig value changed:" << subPath << key;
+            qCDebug(logShortcut) << "DConfig value changed:" << subPath << key;
             if (isKey) {
                 KeyConfig updatedConfig = parseKeyConfig(config);
                 auto existing = std::find_if(m_keys.begin(), m_keys.end(),
@@ -544,17 +546,17 @@ GestureConfig ConfigLoader::parseGestureConfig(DConfig *config)
 
 void ConfigLoader::dumpConfigs()
 {
-    qDebug() << "--- Registered Keybindings (from Config) --- keyEventFlags:1-press,2-release,4-autoRepeat---";
+    qCDebug(logShortcut) << "--- Registered Keybindings (from Config) --- keyEventFlags:1-press,2-release,4-autoRepeat---";
     for (const KeyConfig &config : m_keys) {
-        qDebug().noquote() << QString("  ID: %1").arg(config.getId());
-        qDebug().noquote() << QString("  Hotkeys: %1").arg(config.hotkeys.join(", "));
-        qDebug().noquote() << QString("  Action:  %1").arg(config.triggerValue.join(" "));
-        qDebug().noquote() << QString("  keyEventFlags: %1").arg(config.keyEventFlags);
-        qDebug() << "";
+        qCDebug(logShortcut).noquote() << QString("  ID: %1").arg(config.getId());
+        qCDebug(logShortcut).noquote() << QString("  Hotkeys: %1").arg(config.hotkeys.join(", "));
+        qCDebug(logShortcut).noquote() << QString("  Action:  %1").arg(config.triggerValue.join(" "));
+        qCDebug(logShortcut).noquote() << QString("  keyEventFlags: %1").arg(config.keyEventFlags);
+        qCDebug(logShortcut) << "";
     }
 
     if (!m_gestures.isEmpty()) {
-        qDebug() << "--- Registered Gestures (from Config) ---";
+        qCDebug(logShortcut) << "--- Registered Gestures (from Config) ---";
         for (const GestureConfig &config : m_gestures) {
             QString directionStr;
             switch (config.direction) {
@@ -565,13 +567,13 @@ void ConfigLoader::dumpConfigs()
             default: directionStr = "None"; break;
             }
 
-            qDebug().noquote() << QString("  ID: %1").arg(config.getId());
-            qDebug().noquote() << QString("  Type:    %1 (%2 fingers, %3)")
+            qCDebug(logShortcut).noquote() << QString("  ID: %1").arg(config.getId());
+            qCDebug(logShortcut).noquote() << QString("  Type:    %1 (%2 fingers, %3)")
                                  .arg(config.gestureType == 1 ? "Swipe" : "Hold")
                                  .arg(config.fingerCount)
                                  .arg(directionStr);
-            qDebug().noquote() << QString("  Action:  %1").arg(config.triggerValue.join(" "));
-            qDebug() << "";
+            qCDebug(logShortcut).noquote() << QString("  Action:  %1").arg(config.triggerValue.join(" "));
+            qCDebug(logShortcut) << "";
         }
     }
 }

--- a/src/plugin-qt/shortcut/src/config/customshortcutstore.cpp
+++ b/src/plugin-qt/shortcut/src/config/customshortcutstore.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "customshortcutstore.h"
 
 #include <QDebug>
@@ -59,7 +61,7 @@ bool writeShortcutFields(DConfig *configObject, const KeyConfig &config)
     const QList<QPair<QString, QVariant>> fields = shortcutFields(config);
     for (const auto &field : fields) {
         if (configObject->isReadOnly(field.first)) {
-            qWarning() << "CustomShortcutStore: read-only field:" << field.first
+            qCWarning(logShortcut) << "CustomShortcutStore: read-only field:" << field.first
                        << config.subPath;
             return false;
         }
@@ -72,7 +74,7 @@ bool writeShortcutFields(DConfig *configObject, const KeyConfig &config)
     }
     for (const auto &field : fields) {
         if (!configValuesEqual(configObject->value(field.first), field.second)) {
-            qWarning() << "CustomShortcutStore: field verification failed:"
+            qCWarning(logShortcut) << "CustomShortcutStore: field verification failed:"
                        << field.first << config.subPath;
             return false;
         }
@@ -92,7 +94,7 @@ DConfig *CustomShortcutStore::createConfig(const QString &subPath, QObject *pare
 {
     const QString normalized = normalizeSubPath(subPath);
     if (normalized.isEmpty()) {
-        qWarning() << "CustomShortcutStore: invalid custom shortcut subPath:" << subPath;
+        qCWarning(logShortcut) << "CustomShortcutStore: invalid custom shortcut subPath:" << subPath;
         return nullptr;
     }
     return DConfig::create(APP_ID, CONFIG_NAME_SHORTCUT, QStringLiteral("/") + normalized, parent);
@@ -101,12 +103,12 @@ DConfig *CustomShortcutStore::createConfig(const QString &subPath, QObject *pare
 bool CustomShortcutStore::save(const KeyConfig &config, DConfig *configObject) const
 {
     if (!configObject) {
-        qWarning() << "CustomShortcutStore: missing DConfig object for save:" << config.subPath;
+        qCWarning(logShortcut) << "CustomShortcutStore: missing DConfig object for save:" << config.subPath;
         return false;
     }
 
     const QString subPath = normalizeSubPath(config.subPath);
-    qDebug() << "CustomShortcutStore: saving custom shortcut"
+    qCDebug(logShortcut) << "CustomShortcutStore: saving custom shortcut"
              << "subPath:" << subPath
              << "appId:" << config.appId
              << "displayName:" << config.displayName
@@ -129,12 +131,12 @@ bool CustomShortcutStore::save(const KeyConfig &config, DConfig *configObject) c
 bool CustomShortcutStore::updateCustomShortcutFields(const KeyConfig &config, DConfig *configObject) const
 {
     if (!configObject) {
-        qWarning() << "CustomShortcutStore: missing DConfig object for update:" << config.subPath;
+        qCWarning(logShortcut) << "CustomShortcutStore: missing DConfig object for update:" << config.subPath;
         return false;
     }
 
     const QString subPath = normalizeSubPath(config.subPath);
-    qDebug() << "CustomShortcutStore: updating custom shortcut fields"
+    qCDebug(logShortcut) << "CustomShortcutStore: updating custom shortcut fields"
              << "subPath:" << subPath
              << "displayName:" << config.displayName
              << "argument count:" << config.triggerValue.size()
@@ -156,7 +158,7 @@ void CustomShortcutStore::reset(DConfig *configObject, const QString &subPath) c
         return;
 
     const QString normalized = normalizeSubPath(subPath);
-    qDebug() << "CustomShortcutStore: resetting custom shortcut DConfig:" << normalized;
+    qCDebug(logShortcut) << "CustomShortcutStore: resetting custom shortcut DConfig:" << normalized;
 
     QStringList resetKeys = configObject->keyList();
     resetKeys.append(CustomShortcutKeys);
@@ -178,7 +180,7 @@ QString CustomShortcutStore::normalizeSubPath(const QString &raw)
         || normalized.contains(QLatin1Char('/'))
         || normalized.contains(QLatin1Char('\\'))
         || normalized.contains(QChar::Null)) {
-        qWarning() << "CustomShortcutStore: rejected unsafe subPath:" << raw;
+        qCWarning(logShortcut) << "CustomShortcutStore: rejected unsafe subPath:" << raw;
         return QString();
     }
     return normalized;
@@ -209,7 +211,7 @@ bool CustomShortcutStore::writeSubPaths(const QStringList &subPaths) const
     const QFileInfo info(m_iniPath);
     QDir dir(info.absolutePath());
     if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
-        qWarning() << "CustomShortcutStore: failed to create custom shortcut ini dir:" << info.absolutePath();
+        qCWarning(logShortcut) << "CustomShortcutStore: failed to create custom shortcut ini dir:" << info.absolutePath();
         return false;
     }
 
@@ -227,7 +229,7 @@ bool CustomShortcutStore::writeSubPaths(const QStringList &subPaths) const
     settings.sync();
 
     if (settings.status() != QSettings::NoError) {
-        qWarning() << "CustomShortcutStore: failed to write custom shortcut ini:" << m_iniPath;
+        qCWarning(logShortcut) << "CustomShortcutStore: failed to write custom shortcut ini:" << m_iniPath;
         return false;
     }
     return true;

--- a/src/plugin-qt/shortcut/src/core/actionexecutor.cpp
+++ b/src/plugin-qt/shortcut/src/core/actionexecutor.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "actionexecutor.h"
 #include "commandlineparser.h"
 #include <QProcess>
@@ -15,7 +17,7 @@ ActionExecutor::ActionExecutor(QObject *parent)
 
 void ActionExecutor::execute(const BaseConfig &config)
 {
-    qDebug() << "Executing action for" << config.appId << "Type:" << config.triggerType;
+    qCDebug(logShortcut) << "Executing action for" << config.appId << "Type:" << config.triggerType;
     
     if (config.triggerType == (int)TriggerType::Command) { // Command
         const QStringList command = config.category == QLatin1String(CategoryKey::Custom)
@@ -27,7 +29,7 @@ void ActionExecutor::execute(const BaseConfig &config)
             runApp(config.triggerValue.first());
         }
     } else { // action
-        qWarning() << "Running action by compositor:" << config.triggerType;
+        qCWarning(logShortcut) << "Running action by compositor:" << config.triggerType;
     }
 }
 
@@ -41,12 +43,12 @@ bool ActionExecutor::executeCommand(const QStringList &command)
     if (command.size() > 1)
         argsList << QStringLiteral("--") << command.sliced(1);
 
-    qDebug() << "Running command via dde-am:" << argsList;
+    qCDebug(logShortcut) << "Running command via dde-am:" << argsList;
     return QProcess::startDetached(QStringLiteral("/usr/bin/dde-am"), argsList);
 }
 
 void ActionExecutor::runApp(const QString &appId)
 {
-    qDebug() << "Launching app via dde-am:" << appId;
+    qCDebug(logShortcut) << "Launching app via dde-am:" << appId;
     QProcess::startDetached("/usr/bin/dde-am", {appId});
 }

--- a/src/plugin-qt/shortcut/src/core/customshortcuttransaction.cpp
+++ b/src/plugin-qt/shortcut/src/core/customshortcuttransaction.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "customshortcuttransaction.h"
 
 #include "backend/abstractkeyhandler.h"
@@ -34,21 +36,21 @@ bool KeybindingManager::CustomShortcutTransaction::applyRuntime()
 
     const QStringList excludeIds = changedIds();
     if (!registerIfNeeded(m_change.newTarget, excludeIds)) {
-        qWarning() << "CustomShortcutTransaction: failed to register target shortcut"
+        qCWarning(logShortcut) << "CustomShortcutTransaction: failed to register target shortcut"
                    << m_change.newTarget.getId();
         restoreRuntime();
         return false;
     }
 
     if (m_change.hasConflict && !registerIfNeeded(m_change.newConflict, excludeIds)) {
-        qWarning() << "CustomShortcutTransaction: failed to register conflict shortcut"
+        qCWarning(logShortcut) << "CustomShortcutTransaction: failed to register conflict shortcut"
                    << m_change.oldConflict.getId();
         restoreRuntime();
         return false;
     }
 
     if (!m_manager->m_keyHandler->commitSync()) {
-        qWarning() << "CustomShortcutTransaction: runtime commit failed, rolling back"
+        qCWarning(logShortcut) << "CustomShortcutTransaction: runtime commit failed, rolling back"
                    << m_change.newTarget.getId();
         restoreRuntime();
         return false;
@@ -61,7 +63,7 @@ bool KeybindingManager::CustomShortcutTransaction::applyRuntime()
 bool KeybindingManager::CustomShortcutTransaction::persistAdd()
 {
     if (!m_manager->m_loader->saveCustomShortcut(m_change.newTarget)) {
-        qWarning() << "AddCustomShortcut: failed to persist custom shortcut, rolling back"
+        qCWarning(logShortcut) << "AddCustomShortcut: failed to persist custom shortcut, rolling back"
                    << m_change.newTarget.getId();
         restoreRuntime();
         return false;
@@ -72,11 +74,11 @@ bool KeybindingManager::CustomShortcutTransaction::persistAdd()
         if (!m_manager->m_loader->updateValue(m_change.oldConflict.getId(),
                                               "hotkeys",
                                               m_change.newConflict.hotkeys)) {
-            qWarning() << "AddCustomShortcut: failed to persist conflict shortcut, rolling back"
+            qCWarning(logShortcut) << "AddCustomShortcut: failed to persist conflict shortcut, rolling back"
                        << m_change.oldConflict.getId();
             restoreConflictMap();
             if (!m_manager->m_loader->removeCustomShortcut(m_change.newTarget.getId())) {
-                qCritical() << "AddCustomShortcut: failed to remove persisted custom shortcut during rollback"
+                qCCritical(logShortcut) << "AddCustomShortcut: failed to remove persisted custom shortcut during rollback"
                             << m_change.newTarget.getId();
             }
             restoreRuntime();
@@ -91,10 +93,10 @@ bool KeybindingManager::CustomShortcutTransaction::persistAdd()
 bool KeybindingManager::CustomShortcutTransaction::persistModify()
 {
     if (!m_manager->m_loader->updateCustomShortcut(m_change.newTarget)) {
-        qWarning() << "ModifyCustomShortcut: failed to persist custom shortcut, rolling back"
+        qCWarning(logShortcut) << "ModifyCustomShortcut: failed to persist custom shortcut, rolling back"
                    << m_change.newTarget.getId();
         if (!m_manager->m_loader->updateCustomShortcut(m_change.oldTarget)) {
-            qCritical() << "ModifyCustomShortcut: failed to restore persisted custom shortcut during rollback"
+            qCCritical(logShortcut) << "ModifyCustomShortcut: failed to restore persisted custom shortcut during rollback"
                         << m_change.oldTarget.getId();
         }
         restoreRuntime();
@@ -106,11 +108,11 @@ bool KeybindingManager::CustomShortcutTransaction::persistModify()
         if (!m_manager->m_loader->updateValue(m_change.oldConflict.getId(),
                                               "hotkeys",
                                               m_change.newConflict.hotkeys)) {
-            qWarning() << "ModifyCustomShortcut: failed to persist conflict shortcut, rolling back"
+            qCWarning(logShortcut) << "ModifyCustomShortcut: failed to persist conflict shortcut, rolling back"
                        << m_change.oldConflict.getId();
             restoreConflictMap();
             if (!m_manager->m_loader->updateCustomShortcut(m_change.oldTarget)) {
-                qCritical() << "ModifyCustomShortcut: failed to restore persisted custom shortcut during conflict rollback"
+                qCCritical(logShortcut) << "ModifyCustomShortcut: failed to restore persisted custom shortcut during conflict rollback"
                             << m_change.oldTarget.getId();
             }
             restoreRuntime();
@@ -180,11 +182,11 @@ void KeybindingManager::CustomShortcutTransaction::restoreRuntime()
         restored = registerIfNeeded(m_change.oldTarget, excludeIds) && restored;
 
     if (!restored) {
-        qCritical() << "CustomShortcutTransaction: failed to restore shortcut registration"
+        qCCritical(logShortcut) << "CustomShortcutTransaction: failed to restore shortcut registration"
                     << m_change.newTarget.getId();
     }
     if (!m_manager->m_keyHandler->commitSync()) {
-        qCritical() << "CustomShortcutTransaction: rollback commit failed,"
+        qCCritical(logShortcut) << "CustomShortcutTransaction: rollback commit failed,"
                     << "runtime state may diverge from compositor";
     }
 }

--- a/src/plugin-qt/shortcut/src/core/gesturemanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/gesturemanager.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "gesturemanager.h"
 #include "actionexecutor.h"
 #include "gestureactioncatalog.h"
@@ -77,7 +79,7 @@ void GestureManager::registerAllGestures()
             setGestureActive(config);
     }
 
-    qInfo() << "GestureManager: configured" << m_configuredGestures.size()
+    qCInfo(logShortcut) << "GestureManager: configured" << m_configuredGestures.size()
             << "active" << m_activeGestureIds.size()
             << "backend" << (m_isWayland ? "treeland" : "x11");
 }
@@ -153,7 +155,7 @@ bool GestureManager::ModifyGesture(const QString &id, const QStringList &action)
 {
     const auto it = m_configuredGestures.constFind(id);
     if (it == m_configuredGestures.constEnd() || action.size() != 1) {
-        qWarning() << "GestureManager::ModifyGesture: invalid request:" << id << action;
+        qCWarning(logShortcut) << "GestureManager::ModifyGesture: invalid request:" << id << action;
         return false;
     }
 
@@ -171,7 +173,7 @@ bool GestureManager::ModifyGesture(const QString &id, const QStringList &action)
     const GestureActionMetadata *definition = GestureActionCatalog::find(
             newConfig, newActionId, backend);
     if (!definition) {
-        qWarning() << "GestureManager::ModifyGesture: unknown action:" << id << action.first();
+        qCWarning(logShortcut) << "GestureManager::ModifyGesture: unknown action:" << id << action.first();
         return false;
     }
 
@@ -264,7 +266,7 @@ void GestureManager::onGestureActivated(const QString &gestureId)
 
     const GestureConfig &config = it.value();
     if (config.triggerType == int(TriggerType::Action) && !isActionSupported(config)) {
-        qWarning() << "GestureManager: ignoring unsupported gesture action: gesture"
+        qCWarning(logShortcut) << "GestureManager: ignoring unsupported gesture action: gesture"
                    << gestureId << "configured action" << config.triggerValue.value(0)
                    << "backend" << (m_isWayland ? "treeland" : "x11");
         return;
@@ -314,7 +316,7 @@ bool GestureManager::registerGesture(const GestureConfig &config)
                                                       config.fingerCount,
                                                       config.direction);
     if (!conflictId.isEmpty() && conflictId != config.getId()) {
-        qWarning() << "GestureManager: gesture conflict:" << config.getId() << conflictId;
+        qCWarning(logShortcut) << "GestureManager: gesture conflict:" << config.getId() << conflictId;
         return false;
     }
     GestureConfig backendConfig = config;
@@ -323,7 +325,7 @@ bool GestureManager::registerGesture(const GestureConfig &config)
         const GestureActionMetadata *definition = GestureActionCatalog::find(
                 config, configuredAction, backend);
         if (!definition) {
-            qWarning() << "GestureManager: unsupported gesture action: gesture"
+            qCWarning(logShortcut) << "GestureManager: unsupported gesture action: gesture"
                        << config.getId() << "configured action"
                        << config.triggerValue.value(0) << "backend"
                        << (m_isWayland ? "treeland" : "x11");

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "keybindingmanager.h"
 #include "commandlineparser.h"
 #include "customshortcuttransaction.h"
@@ -343,7 +345,7 @@ KeybindingManager::~KeybindingManager() = default;
 
 void KeybindingManager::registerAllShortcuts()
 {
-    qDebug() << "KeybindingManager: Registering all shortcuts...";
+    qCDebug(logShortcut) << "KeybindingManager: Registering all shortcuts...";
     for (const QString &id : m_activeShortcutIds.values())
         unregisterShortcut(id);
 
@@ -359,16 +361,16 @@ void KeybindingManager::registerAllShortcuts()
         config.hotkeys = normalizeHotkeys(config.hotkeys);
         m_keyConfigsMap[config.getId()] = config;
         if (config.canRegister() && !registerShortcut(config))
-            qWarning() << "KeybindingManager: configured shortcut is inactive:" << config.getId();
+            qCWarning(logShortcut) << "KeybindingManager: configured shortcut is inactive:" << config.getId();
     }
 
-    qInfo() << "KeybindingManager: configured" << m_keyConfigsMap.size()
+    qCInfo(logShortcut) << "KeybindingManager: configured" << m_keyConfigsMap.size()
             << "active" << m_activeShortcutIds.size();
 }
 
 void KeybindingManager::clearState()
 {
-    qWarning() << "KeybindingManager: Marking runtime bindings inactive due to protocol disconnection";
+    qCWarning(logShortcut) << "KeybindingManager: Marking runtime bindings inactive due to protocol disconnection";
     m_specialKeyHandler->clear();
     m_activeShortcutIds.clear();
 }
@@ -526,7 +528,7 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
 
     KeyConfig config = m_keyConfigsMap[id];
     if (!config.enabled || !config.modifiable) {
-        qWarning() << "Shortcut is not modifiable or enabled:" << id << "enabled:"
+        qCWarning(logShortcut) << "Shortcut is not modifiable or enabled:" << id << "enabled:"
                     << config.enabled << "modifiable:" << config.modifiable;
         return false;
     }
@@ -536,7 +538,7 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
     const QStringList normalized = normalizeHotkeys(newHotkeys);
     if (normalized.isEmpty() || containsEmptyHotkey(normalized)
             || !areValidShortcutHotkeys(normalized)) {
-        qWarning() << "ModifyHotkeys: new hotkeys can not be empty:" << id;
+        qCWarning(logShortcut) << "ModifyHotkeys: new hotkeys can not be empty:" << id;
         return false;
     }
 
@@ -544,7 +546,7 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
     for (const QString &hotkey : normalized) {
         ShortcutInfo conflictInfo = LookupConflictShortcut(hotkey);
         if (!conflictInfo.id.isEmpty() && conflictInfo.id != id) {
-            qWarning() << "Conflict detected with:" << conflictInfo.id << conflictInfo.displayName;
+            qCWarning(logShortcut) << "Conflict detected with:" << conflictInfo.id << conflictInfo.displayName;
             return false;
         }
     }
@@ -557,7 +559,7 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
     config.hotkeys = normalized;
 
     if (!registerShortcut(config, QStringList{id})) {
-        qWarning() << "Failed to register new hotkeys:" << id << normalized;
+        qCWarning(logShortcut) << "Failed to register new hotkeys:" << id << normalized;
         config.hotkeys = oldHotkeys;
         registerShortcut(config, QStringList{id});
         m_keyHandler->commitSync();
@@ -566,7 +568,7 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
 
     // Phase 2: commit to compositor (sync — must know whether to roll back).
     if (!m_keyHandler->commitSync()) {
-        qWarning() << "Shortcut commit failed for ModifyHotkeys:" << id;
+        qCWarning(logShortcut) << "Shortcut commit failed for ModifyHotkeys:" << id;
         unregisterShortcut(id);
         config.hotkeys = oldHotkeys;
         registerShortcut(config, QStringList{id});
@@ -578,7 +580,7 @@ bool KeybindingManager::ModifyHotkeys(const QString &id, const QStringList &newH
     config.hotkeys = normalized;
     m_keyConfigsMap[id] = config;
     if (!m_loader->updateValue(id, "hotkeys", normalized)) {
-        qWarning() << "ModifyHotkeys: failed to persist hotkeys, rolling back:" << id;
+        qCWarning(logShortcut) << "ModifyHotkeys: failed to persist hotkeys, rolling back:" << id;
         config.hotkeys = oldHotkeys;
         m_keyConfigsMap[id] = config;
         unregisterShortcut(id);
@@ -601,7 +603,7 @@ QString KeybindingManager::AddCustomShortcutWithConflict(const QString &name, co
                                                           const QString &expectedConflictId)
 {
     if (expectedConflictId.trimmed().isEmpty()) {
-        qWarning() << "AddCustomShortcutWithConflict: expected conflict id is empty";
+        qCWarning(logShortcut) << "AddCustomShortcutWithConflict: expected conflict id is empty";
         return QString();
     }
 
@@ -617,7 +619,7 @@ QString KeybindingManager::addCustomShortcut(const QString &name, const QString 
     const QString normalizedHotkey = normalizeHotkey(hotkey);
 
     if (runtimeCustomShortcutCount() >= MaxCustomShortcutCount) {
-        qWarning() << "AddCustomShortcut: custom shortcut count limit reached";
+        qCWarning(logShortcut) << "AddCustomShortcut: custom shortcut count limit reached";
         return QString();
     }
 
@@ -625,7 +627,7 @@ QString KeybindingManager::addCustomShortcut(const QString &name, const QString 
     if (!isValidCustomShortcutName(displayName)
         || !commandArguments
         || !isValidCustomShortcutHotkey(normalizedHotkey, false)) {
-        qWarning() << "AddCustomShortcut: invalid input";
+        qCWarning(logShortcut) << "AddCustomShortcut: invalid input";
         return QString();
     }
     KeyConfig config;
@@ -643,7 +645,7 @@ QString KeybindingManager::addCustomShortcut(const QString &name, const QString 
 
     CustomShortcutTransaction transaction(this, change);
     if (!transaction.applyRuntime()) {
-        qWarning() << "AddCustomShortcut: failed to apply runtime change" << config.getId();
+        qCWarning(logShortcut) << "AddCustomShortcut: failed to apply runtime change" << config.getId();
         return QString();
     }
 
@@ -666,7 +668,7 @@ bool KeybindingManager::ModifyCustomShortcutWithConflict(const QString &id, cons
                                                          const QString &expectedConflictId)
 {
     if (expectedConflictId.trimmed().isEmpty()) {
-        qWarning() << "ModifyCustomShortcutWithConflict: expected conflict id is empty";
+        qCWarning(logShortcut) << "ModifyCustomShortcutWithConflict: expected conflict id is empty";
         return false;
     }
 
@@ -683,7 +685,7 @@ bool KeybindingManager::modifyCustomShortcut(const QString &id, const QString &n
 
     KeyConfig oldConfig = m_keyConfigsMap[id];
     if (!isRuntimeCustomShortcut(oldConfig)) {
-        qWarning() << "ModifyCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
+        qCWarning(logShortcut) << "ModifyCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
         return false;
     }
 
@@ -694,7 +696,7 @@ bool KeybindingManager::modifyCustomShortcut(const QString &id, const QString &n
     if (!isValidCustomShortcutName(displayName)
         || !commandArguments
         || !isValidCustomShortcutHotkey(normalizedHotkey, true)) {
-        qWarning() << "ModifyCustomShortcut: invalid input" << id;
+        qCWarning(logShortcut) << "ModifyCustomShortcut: invalid input" << id;
         return false;
     }
     KeyConfig newConfig = oldConfig;
@@ -703,7 +705,7 @@ bool KeybindingManager::modifyCustomShortcut(const QString &id, const QString &n
     const bool hotkeysChanged = oldConfig.hotkeys != newConfig.hotkeys;
     if (!hotkeysChanged) {
         if (!expectedConflictId.isEmpty()) {
-            qWarning() << "ModifyCustomShortcutWithConflict: hotkey is unchanged:" << id;
+            qCWarning(logShortcut) << "ModifyCustomShortcutWithConflict: hotkey is unchanged:" << id;
             return false;
         }
 
@@ -711,7 +713,7 @@ bool KeybindingManager::modifyCustomShortcut(const QString &id, const QString &n
             return true;
 
         if (!m_loader->updateCustomShortcut(newConfig)) {
-            qWarning() << "ModifyCustomShortcut: failed to persist custom shortcut:" << id;
+            qCWarning(logShortcut) << "ModifyCustomShortcut: failed to persist custom shortcut:" << id;
             return false;
         }
 
@@ -730,7 +732,7 @@ bool KeybindingManager::modifyCustomShortcut(const QString &id, const QString &n
 
     CustomShortcutTransaction transaction(this, change);
     if (!transaction.applyRuntime()) {
-        qWarning() << "ModifyCustomShortcut: failed to apply runtime change" << id;
+        qCWarning(logShortcut) << "ModifyCustomShortcut: failed to apply runtime change" << id;
         return false;
     }
 
@@ -749,20 +751,20 @@ bool KeybindingManager::DeleteCustomShortcut(const QString &id)
 
     KeyConfig oldConfig = m_keyConfigsMap[id];
     if (!isRuntimeCustomShortcut(oldConfig)) {
-        qWarning() << "DeleteCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
+        qCWarning(logShortcut) << "DeleteCustomShortcut: shortcut is not a runtime custom shortcut:" << id;
         return false;
     }
 
     unregisterShortcut(id);
     if (!m_keyHandler->commitSync()) {
-        qWarning() << "DeleteCustomShortcut: commit failed" << id;
+        qCWarning(logShortcut) << "DeleteCustomShortcut: commit failed" << id;
         if (registerShortcut(oldConfig, QStringList{id}))
             m_keyHandler->commitSync();
         return false;
     }
 
     if (!m_loader->removeCustomShortcut(id)) {
-        qWarning() << "DeleteCustomShortcut: failed to remove persisted custom shortcut, restoring" << id;
+        qCWarning(logShortcut) << "DeleteCustomShortcut: failed to remove persisted custom shortcut, restoring" << id;
         if (registerShortcut(oldConfig, QStringList{id}))
             m_keyHandler->commitSync();
         return false;
@@ -785,12 +787,12 @@ bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
     KeyConfig config2 = m_keyConfigsMap[id2];
 
     if (!config1.enabled || !config1.modifiable || !config2.enabled || !config2.modifiable) {
-        qWarning() << "SwapHotkeys: both shortcuts must be enabled and modifiable:"
+        qCWarning(logShortcut) << "SwapHotkeys: both shortcuts must be enabled and modifiable:"
                     << id1 << id2;
         return false;
     }
     if (!canPersistShortcutHotkeys(config1) || !canPersistShortcutHotkeys(config2)) {
-        qWarning() << "SwapHotkeys: both shortcuts must have writable configs:"
+        qCWarning(logShortcut) << "SwapHotkeys: both shortcuts must have writable configs:"
                     << id1 << m_loader->canUpdateValue(id1)
                     << id2 << m_loader->canUpdateValue(id2);
         return false;
@@ -810,7 +812,7 @@ bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
     bool reg2 = registerShortcut(config2, QStringList{id1, id2});
 
     if (!reg1 || !reg2) {
-        qWarning() << "SwapHotkeys: registerKey failed" << id1 << reg1 << id2 << reg2;
+        qCWarning(logShortcut) << "SwapHotkeys: registerKey failed" << id1 << reg1 << id2 << reg2;
         if (rollbackRegistration(id1, id2, config1, config2, hotkeys1, hotkeys2) == RollbackResult::RebuildRequired)
             rebuildPersistedShortcutPair(id1, id2);
 
@@ -820,7 +822,7 @@ bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
     // Phase 2: commit to compositor.  Do NOT update m_keyConfigsMap yet
     // — if commit fails we want the map to still hold the originals.
     if (!m_keyHandler->commitSync()) {
-        qWarning() << "SwapHotkeys: commit failed";
+        qCWarning(logShortcut) << "SwapHotkeys: commit failed";
         unregisterShortcut(id1);
         unregisterShortcut(id2);
         if (rollbackRegistration(id1, id2, config1, config2, hotkeys1, hotkeys2) == RollbackResult::RebuildRequired)
@@ -833,11 +835,11 @@ bool KeybindingManager::SwapHotkeys(const QString &id1, const QString &id2)
     const bool persisted1 = m_loader->updateValue(id1, "hotkeys", config1.hotkeys);
     const bool persisted2 = persisted1 && m_loader->updateValue(id2, "hotkeys", config2.hotkeys);
     if (!persisted2) {
-        qWarning() << "SwapHotkeys: persistence failed, rolling back" << id1 << id2;
+        qCWarning(logShortcut) << "SwapHotkeys: persistence failed, rolling back" << id1 << id2;
         const bool compensated1 = m_loader->updateValue(id1, "hotkeys", hotkeys1);
         const bool compensated2 = !persisted1 || m_loader->updateValue(id2, "hotkeys", hotkeys2);
         if (!compensated1 || !compensated2) {
-            qCritical() << "SwapHotkeys: persistence compensation failed, rebuilding from DConfig" << id1 << id2;
+            qCCritical(logShortcut) << "SwapHotkeys: persistence compensation failed, rebuilding from DConfig" << id1 << id2;
             rebuildPersistedShortcutPair(id1, id2);
             return false;
         }
@@ -869,7 +871,7 @@ KeybindingManager::RollbackResult KeybindingManager::rollbackRegistration(const 
     const bool registered1 = !config1.canRegister() || registerShortcut(config1, QStringList{id1, id2});
     const bool registered2 = !config2.canRegister() || registerShortcut(config2, QStringList{id1, id2});
     if (!registered1 || !registered2) {
-        qCritical() << "rollbackRegistration: failed to restore runtime bindings:"
+        qCCritical(logShortcut) << "rollbackRegistration: failed to restore runtime bindings:"
                     << id1 << registered1 << id2 << registered2;
         unregisterShortcut(id1);
         unregisterShortcut(id2);
@@ -877,7 +879,7 @@ KeybindingManager::RollbackResult KeybindingManager::rollbackRegistration(const 
     }
 
     if (!m_keyHandler->commitSync()) {
-        qCritical() << "rollbackRegistration: commitSync failed";
+        qCCritical(logShortcut) << "rollbackRegistration: commitSync failed";
         unregisterShortcut(id1);
         unregisterShortcut(id2);
         return RollbackResult::RebuildRequired;
@@ -895,7 +897,7 @@ void KeybindingManager::rebuildPersistedShortcutPair(const QString &id1, const Q
     unregisterShortcut(id1);
     unregisterShortcut(id2);
     if (!m_keyHandler->commitSync()) {
-        qCritical() << "Failed to commit shortcut cleanup before DConfig rebuild:" << id1 << id2;
+        qCCritical(logShortcut) << "Failed to commit shortcut cleanup before DConfig rebuild:" << id1 << id2;
     }
 
     KeyConfig config1;
@@ -927,18 +929,18 @@ void KeybindingManager::rebuildPersistedShortcutPair(const QString &id1, const Q
         registered2 = registerShortcut(config2, QStringList{id1, id2});
 
     if (!registered1 || !registered2) {
-        qWarning() << "Failed to fully rebuild shortcuts from DConfig:"
+        qCWarning(logShortcut) << "Failed to fully rebuild shortcuts from DConfig:"
                    << id1 << registered1 << id2 << registered2;
         unregisterShortcut(id1);
         unregisterShortcut(id2);
     }
     if ((registered1 && registered2 && !m_keyHandler->commitSync())
             || (!registered1 || !registered2)) {
-        qCritical() << "Failed to commit shortcuts rebuilt from DConfig:" << id1 << id2;
+        qCCritical(logShortcut) << "Failed to commit shortcuts rebuilt from DConfig:" << id1 << id2;
         unregisterShortcut(id1);
         unregisterShortcut(id2);
         if (!m_keyHandler->commitSync())
-            qCritical() << "Failed to commit cleanup after DConfig rebuild;"
+            qCCritical(logShortcut) << "Failed to commit cleanup after DConfig rebuild;"
                         << "local runtime mappings remain empty:" << id1 << id2;
     }
 
@@ -948,7 +950,7 @@ void KeybindingManager::rebuildPersistedShortcutPair(const QString &id1, const Q
         emit ShortcutChanged(id2, toShortcutInfo(config2));
 
     if (!loaded1 || !loaded2)
-        qCritical() << "Failed to reload shortcut configuration:" << id1 << loaded1 << id2 << loaded2;
+        qCCritical(logShortcut) << "Failed to reload shortcut configuration:" << id1 << loaded1 << id2 << loaded2;
 }
 
 bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &newHotkey, const QString &conflictId)
@@ -961,15 +963,15 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
     KeyConfig conflictConfig = m_keyConfigsMap[conflictId];
 
     if (!targetConfig.enabled || !targetConfig.modifiable) {
-        qWarning() << "ReplaceHotkey: target not modifiable or enabled:" << targetId;
+        qCWarning(logShortcut) << "ReplaceHotkey: target not modifiable or enabled:" << targetId;
         return false;
     }
     if (!conflictConfig.enabled || !conflictConfig.modifiable) {
-        qWarning() << "ReplaceHotkey: conflict shortcut not modifiable or enabled:" << conflictId;
+        qCWarning(logShortcut) << "ReplaceHotkey: conflict shortcut not modifiable or enabled:" << conflictId;
         return false;
     }
     if (!canPersistShortcutHotkeys(targetConfig) || !canPersistShortcutHotkeys(conflictConfig)) {
-        qWarning() << "ReplaceHotkey: target and conflict shortcuts must have writable configs:"
+        qCWarning(logShortcut) << "ReplaceHotkey: target and conflict shortcuts must have writable configs:"
                     << targetId << m_loader->canUpdateValue(targetId)
                     << conflictId << m_loader->canUpdateValue(conflictId);
         return false;
@@ -977,13 +979,13 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
 
     const QString normalized = normalizeHotkey(newHotkey);
     if (normalized.trimmed().isEmpty() || !isValidCustomShortcutHotkey(normalized, false)) {
-        qWarning() << "ReplaceHotkey: new hotkey can not be empty:" << targetId;
+        qCWarning(logShortcut) << "ReplaceHotkey: new hotkey can not be empty:" << targetId;
         return false;
     }
 
     // Remove the hotkey from the conflict shortcut
     if (!conflictConfig.hotkeys.removeOne(normalized)) {
-        qWarning() << "ReplaceHotkey: hotkey" << normalized << "not found in conflict shortcut" << conflictId;
+        qCWarning(logShortcut) << "ReplaceHotkey: hotkey" << normalized << "not found in conflict shortcut" << conflictId;
         return false;
     }
 
@@ -1006,7 +1008,7 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
     }
 
     if (!regTarget || !regConflict) {
-        qWarning() << "ReplaceHotkey: registerKey failed" << targetId << regTarget << conflictId << regConflict;
+        qCWarning(logShortcut) << "ReplaceHotkey: registerKey failed" << targetId << regTarget << conflictId << regConflict;
         unregisterShortcut(targetId);
         unregisterShortcut(conflictId);
         if (rollbackRegistration(targetId, conflictId, targetConfig, conflictConfig,
@@ -1018,7 +1020,7 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
 
     // Phase 2: commit to compositor
     if (!m_keyHandler->commitSync()) {
-        qWarning() << "ReplaceHotkey: commit failed";
+        qCWarning(logShortcut) << "ReplaceHotkey: commit failed";
         unregisterShortcut(targetId);
         unregisterShortcut(conflictId);
         if (rollbackRegistration(targetId, conflictId, targetConfig, conflictConfig,
@@ -1033,12 +1035,12 @@ bool KeybindingManager::ReplaceHotkey(const QString &targetId, const QString &ne
     const bool conflictPersisted = targetPersisted
             && m_loader->updateValue(conflictId, "hotkeys", conflictConfig.hotkeys);
     if (!conflictPersisted) {
-        qWarning() << "ReplaceHotkey: persistence failed, rolling back" << targetId << conflictId;
+        qCWarning(logShortcut) << "ReplaceHotkey: persistence failed, rolling back" << targetId << conflictId;
         const bool targetCompensated = m_loader->updateValue(targetId, "hotkeys", oldTargetHotkeys);
         const bool conflictCompensated = !targetPersisted
                 || m_loader->updateValue(conflictId, "hotkeys", oldConflictHotkeys);
         if (!targetCompensated || !conflictCompensated) {
-            qCritical() << "ReplaceHotkey: persistence compensation failed, rebuilding from DConfig" << targetId << conflictId;
+            qCCritical(logShortcut) << "ReplaceHotkey: persistence compensation failed, rebuilding from DConfig" << targetId << conflictId;
             rebuildPersistedShortcutPair(targetId, conflictId);
             return false;
         }
@@ -1092,7 +1094,7 @@ bool KeybindingManager::Disable(const QString &id)
 
 void KeybindingManager::ReloadConfigs()
 {
-    qInfo() << "ReloadConfigs called via DBus (delegating to Smart ConfigLoader)";
+    qCInfo(logShortcut) << "ReloadConfigs called via DBus (delegating to Smart ConfigLoader)";
     
     // ConfigLoader will calculate diff (Add/Remove) and emit:
     // - configRemoved(id) -> Triggers unregister
@@ -1124,7 +1126,7 @@ void KeybindingManager::Reset()
     }
 
     if (!m_keyHandler->commitSync()) {
-        qWarning() << "Reset: failed to commit unregistering existing hotkeys";
+        qCWarning(logShortcut) << "Reset: failed to commit unregistering existing hotkeys";
         for (const QString &id : std::as_const(toRestore)) {
             const KeyConfig config = m_keyConfigsMap.value(id);
             if (config.canRegister())
@@ -1146,7 +1148,7 @@ void KeybindingManager::onKeyConfigAdded(const KeyConfig &loadedConfig)
     if (config.canRegister()) {
         const bool registered = registerShortcut(config, QStringList{config.getId()});
         if (!registered || !m_keyHandler->commitSync()) {
-            qWarning() << "KeybindingManager: new shortcut is inactive:" << config.getId();
+            qCWarning(logShortcut) << "KeybindingManager: new shortcut is inactive:" << config.getId();
             unregisterShortcut(config.getId());
             m_keyHandler->commitSync();
         }
@@ -1167,7 +1169,7 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &loadedConfig)
         if (config.canRegister() && !m_activeShortcutIds.contains(config.getId())) {
             const bool registered = registerShortcut(config, QStringList{config.getId()});
             if (!registered || !m_keyHandler->commitSync()) {
-                qWarning() << "KeybindingManager: failed to restore inactive shortcut:"
+                qCWarning(logShortcut) << "KeybindingManager: failed to restore inactive shortcut:"
                            << config.getId();
                 unregisterShortcut(config.getId());
                 m_keyHandler->commitSync();
@@ -1192,9 +1194,9 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &loadedConfig)
 
     if (oldWasActive || registered) {
         if (!registered && config.canRegister())
-            qWarning() << "KeybindingManager: changed shortcut is inactive:" << config.getId();
+            qCWarning(logShortcut) << "KeybindingManager: changed shortcut is inactive:" << config.getId();
         if (!m_keyHandler->commitSync()) {
-            qWarning() << "KeybindingManager: config change commit failed, leaving shortcut inactive:"
+            qCWarning(logShortcut) << "KeybindingManager: config change commit failed, leaving shortcut inactive:"
                        << config.getId();
         }
     }
@@ -1218,15 +1220,15 @@ void KeybindingManager::onConfigRemoved(const QString &id)
         // configRemoved is shared by key/gesture; suffix says it's ours but
         // it's not in the map — registerShortcut() must have failed at init.
         // Worth a warning.
-        qWarning() << "KeybindingManager: shortcut id removed but was never registered:" << id;
+        qCWarning(logShortcut) << "KeybindingManager: shortcut id removed but was never registered:" << id;
     } else {
-        qDebug() << "KeybindingManager: ignoring removal of non-key id:" << id;
+        qCDebug(logShortcut) << "KeybindingManager: ignoring removal of non-key id:" << id;
     }
 }
 
 void KeybindingManager::onKeyActivated(const QString &shortcutId)
 {
-    qDebug() << "Key activated:" << shortcutId;
+    qCDebug(logShortcut) << "Key activated:" << shortcutId;
     
     if (m_keyConfigsMap.contains(shortcutId) && m_activeShortcutIds.contains(shortcutId)) {
         const auto &config = m_keyConfigsMap[shortcutId];
@@ -1248,7 +1250,7 @@ void KeybindingManager::onCaptureKeyEvent(bool pressed, const QString &keystroke
 bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringList &excludeIds)
 {
     if (!config.canRegister()) {
-        qWarning() << "Shortcut can not be registered, skipping:"
+        qCWarning(logShortcut) << "Shortcut can not be registered, skipping:"
                    << "Enabled:" << config.enabled
                    << "AppId:" << config.appId
                    << "DisplayName:" << config.displayName
@@ -1256,7 +1258,7 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringL
         return false;
     }
     if (config.hotkeys.size() > MaxShortcutHotkeyCount) {
-        qWarning() << "Shortcut has too many hotkeys, keeping it configured but inactive:"
+        qCWarning(logShortcut) << "Shortcut has too many hotkeys, keeping it configured but inactive:"
                    << config.getId() << config.hotkeys.size();
         return false;
     }
@@ -1272,7 +1274,7 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringL
         seenHotkeys.insert(hotkey);
 
         if (!isValidCustomShortcutHotkey(hotkey, false)) {
-            qWarning() << "Shortcut contains an invalid hotkey, skipping:" << config.getId() << hotkey;
+            qCWarning(logShortcut) << "Shortcut contains an invalid hotkey, skipping:" << config.getId() << hotkey;
             continue;
         }
 
@@ -1295,7 +1297,7 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringL
         for (const QString &hotkey : normalHotkeys) {
             const QString conflictId = lookupRuntimeConflict(hotkey, excludeIds);
             if (!conflictId.isEmpty()) {
-                qWarning() << "Shortcut conflict detected during init:"
+                qCWarning(logShortcut) << "Shortcut conflict detected during init:"
                             << "Config appId:" << config.appId
                             << "Config displayName:" << config.displayName
                             << "Config hotkeys:" << config.hotkeys
@@ -1357,10 +1359,10 @@ QString KeybindingManager::lookupRuntimeConflict(const QString &hotkey,
 
 void KeybindingManager::onBackendKeymapChanged()
 {
-    qInfo() << "KeybindingManager: keyboard mapping changed, rebuilding X11 grabs";
+    qCInfo(logShortcut) << "KeybindingManager: keyboard mapping changed, rebuilding X11 grabs";
     for (const KeyConfig &config : std::as_const(m_keyConfigsMap)) {
         if (config.canRegister() && !registerShortcut(config, QStringList{config.getId()})) {
-            qWarning() << "KeybindingManager: shortcut remains inactive after keymap change:" << config.getId();
+            qCWarning(logShortcut) << "KeybindingManager: shortcut remains inactive after keymap change:" << config.getId();
         }
     }
     m_keyHandler->commitSync();
@@ -1511,7 +1513,7 @@ bool KeybindingManager::prepareConflictShortcutChange(const QString &hotkey,
         if (expectedConflictId.isEmpty())
             return true;
 
-        qWarning() << "prepareConflictShortcutChange: expected conflict for empty hotkey:" << expectedConflictId;
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: expected conflict for empty hotkey:" << expectedConflictId;
         return false;
     }
 
@@ -1520,29 +1522,29 @@ bool KeybindingManager::prepareConflictShortcutChange(const QString &hotkey,
         if (expectedConflictId.isEmpty())
             return true;
 
-        qWarning() << "prepareConflictShortcutChange: expected conflict no longer exists:" << expectedConflictId;
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: expected conflict no longer exists:" << expectedConflictId;
         return false;
     }
 
     if (expectedConflictId.isEmpty()) {
-        qWarning() << "prepareConflictShortcutChange: unconfirmed conflict:" << conflictInfo.id;
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: unconfirmed conflict:" << conflictInfo.id;
         return false;
     }
 
     if (conflictInfo.id != expectedConflictId) {
-        qWarning() << "prepareConflictShortcutChange: conflict changed, expected:"
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: conflict changed, expected:"
                    << expectedConflictId << "actual:" << conflictInfo.id;
         return false;
     }
 
     if (!m_keyConfigsMap.contains(conflictInfo.id)) {
-        qWarning() << "prepareConflictShortcutChange: conflict shortcut is missing:" << conflictInfo.id;
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: conflict shortcut is missing:" << conflictInfo.id;
         return false;
     }
 
     KeyConfig conflictConfig = m_keyConfigsMap.value(conflictInfo.id);
     if (!canPersistShortcutHotkeys(conflictConfig)) {
-        qWarning() << "prepareConflictShortcutChange: conflict shortcut can not be replaced:"
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: conflict shortcut can not be replaced:"
                     << conflictInfo.id
                     << "modifiable:" << conflictConfig.modifiable
                     << "has writable config:" << m_loader->canUpdateValue(conflictInfo.id);
@@ -1551,7 +1553,7 @@ bool KeybindingManager::prepareConflictShortcutChange(const QString &hotkey,
 
     KeyConfig newConflictConfig = conflictConfig;
     if (!newConflictConfig.hotkeys.removeOne(normalizedHotkey)) {
-        qWarning() << "prepareConflictShortcutChange: hotkey not found in conflict shortcut:"
+        qCWarning(logShortcut) << "prepareConflictShortcutChange: hotkey not found in conflict shortcut:"
                    << normalizedHotkey << conflictInfo.id;
         return false;
     }

--- a/src/plugin-qt/shortcut/src/core/serviceactionexecutor.cpp
+++ b/src/plugin-qt/shortcut/src/core/serviceactionexecutor.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "serviceactionexecutor.h"
 #include "actionexecutor.h"
 
@@ -59,7 +61,7 @@ bool ServiceActionExecutor::execute(TriggerActionId actionId, const QString &con
     }
 
     if (!success) {
-        qWarning() << "ServiceActionExecutor: action failed:" << int(actionId)
+        qCWarning(logShortcut) << "ServiceActionExecutor: action failed:" << int(actionId)
                    << "context" << context;
     }
     return success;
@@ -79,10 +81,10 @@ bool ServiceActionExecutor::call(
             [actionId, context](QDBusPendingCallWatcher *finishedWatcher) {
         const QDBusPendingReply<> reply = *finishedWatcher;
         if (reply.isError()) {
-            qWarning() << "ServiceActionExecutor: action failed:" << int(actionId)
+            qCWarning(logShortcut) << "ServiceActionExecutor: action failed:" << int(actionId)
                        << "context" << context << reply.error().message();
         } else {
-            qDebug() << "ServiceActionExecutor: action completed:" << int(actionId)
+            qCDebug(logShortcut) << "ServiceActionExecutor: action completed:" << int(actionId)
                      << "context" << context;
         }
         finishedWatcher->deleteLater();

--- a/src/plugin-qt/shortcut/src/core/shortcutmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/shortcutmanager.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "shortcutmanager.h"
 #include "keybindingmanager.h"
 #include "gesturemanager.h"
@@ -55,7 +57,7 @@ bool ShortcutManager::init()
     }
 
     if (!m_keyHandler || !m_keyHandler->isAvailable()) {
-        qCritical() << "ShortcutManager: Key handler backend not available";
+        qCCritical(logShortcut) << "ShortcutManager: Key handler backend not available";
         return false;
     }
 
@@ -95,7 +97,7 @@ bool ShortcutManager::registerDBusService()
 
     // Register Keybinding service
     if (!connection.registerService("org.deepin.dde.Keybinding1")) {
-        qCritical() << "Failed to register DBus service org.deepin.dde.Keybinding1";
+        qCCritical(logShortcut) << "Failed to register DBus service org.deepin.dde.Keybinding1";
         return false;
     }
 
@@ -103,26 +105,26 @@ bool ShortcutManager::registerDBusService()
                                    QDBusConnection::ExportAllSlots | 
                                    QDBusConnection::ExportAllSignals |
                                    QDBusConnection::ExportAllProperties)) {
-        qCritical() << "Failed to register DBus object for Keybinding1";
+        qCCritical(logShortcut) << "Failed to register DBus object for Keybinding1";
         return false;
     }
 
-    qInfo() << "Deepin Keybinding Service started.";
+    qCInfo(logShortcut) << "Deepin Keybinding Service started.";
 
     // Register Gesture service
     if (m_gestureManager) {
         if (!connection.registerService("org.deepin.dde.Gesture1")) {
-            qCritical() << "Failed to register DBus service org.deepin.dde.Gesture1";
+            qCCritical(logShortcut) << "Failed to register DBus service org.deepin.dde.Gesture1";
             return false;
         }
 
         if (!connection.registerObject("/org/deepin/dde/Gesture1", m_gestureManager,
                                     QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals)) {
-            qCritical() << "Failed to register DBus object for Gesture1";
+            qCCritical(logShortcut) << "Failed to register DBus object for Gesture1";
             return false;
         }
 
-        qInfo() << "Deepin Gesture Service started.";
+        qCInfo(logShortcut) << "Deepin Gesture Service started.";
     }
 
     return true;
@@ -130,7 +132,7 @@ bool ShortcutManager::registerDBusService()
 
 void ShortcutManager::registerAll()
 {
-    qInfo() << "ShortcutManager: Protocol ready, registering all shortcuts and gestures...";
+    qCInfo(logShortcut) << "ShortcutManager: Protocol ready, registering all shortcuts and gestures...";
     // Register all shortcuts
     m_keybindingManager->registerAllShortcuts();
 
@@ -142,16 +144,16 @@ void ShortcutManager::registerAll()
     if (m_isWayland) {
         bool success = m_treelandShortcutWrapper->commitAndWait();
         if (success) {
-            qInfo() << "ShortcutManager: All shortcuts and gestures registered successfully";
+            qCInfo(logShortcut) << "ShortcutManager: All shortcuts and gestures registered successfully";
         } else {
-            qWarning() << "ShortcutManager: Commit failed";
+            qCWarning(logShortcut) << "ShortcutManager: Commit failed";
         }
     }
 }
 
 void ShortcutManager::onProtocolInactive()
 {
-    qWarning() << "ShortcutManager: Protocol inactive, clearing state...";
+    qCWarning(logShortcut) << "ShortcutManager: Protocol inactive, clearing state...";
     
     // Clear state in both managers
     if (m_keybindingManager) {

--- a/src/plugin-qt/shortcut/src/core/translationmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/translationmanager.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include "translationmanager.h"
 
 #include <QCoreApplication>
@@ -36,7 +38,7 @@ void TranslationManager::reload()
     
     QDir dir(getTranslationPath());
     if (!dir.exists()) {
-        qWarning() << "Translation directory does not exist:" << dir.absolutePath();
+        qCWarning(logShortcut) << "Translation directory does not exist:" << dir.absolutePath();
         return;
     }
 
@@ -48,16 +50,16 @@ void TranslationManager::reload()
         // Look for {appId}_{lang}.qm
         QString fileName = QString("%1_%2.qm").arg(appId).arg(currentLanguage);
         if (!appDir.exists(fileName)) {
-            qWarning() << "Translation file does not exist:" << fileName << "for language:" << currentLanguage;
+            qCWarning(logShortcut) << "Translation file does not exist:" << fileName << "for language:" << currentLanguage;
             continue;
         }
         
         QTranslator *translator = new QTranslator(this);
         if (translator->load(appDir.absoluteFilePath(fileName))) {
-            qInfo() << "Loaded translator for appId:" << appId << "from" << appDir.absoluteFilePath(fileName);
+            qCInfo(logShortcut) << "Loaded translator for appId:" << appId << "from" << appDir.absoluteFilePath(fileName);
             m_translators.insert(appId, translator);
         } else {
-            qWarning() << "Failed to load translator for appId:" << appId << "from" << appDir.absoluteFilePath(fileName);
+            qCWarning(logShortcut) << "Failed to load translator for appId:" << appId << "from" << appDir.absoluteFilePath(fileName);
             delete translator;
         }
     }
@@ -73,7 +75,7 @@ QString TranslationManager::translate(const QString &appId, const QString &key) 
         }
     }
 
-    qDebug() << "Translation not found for key:" << key << "in appId:" << appId;
+    qCDebug(logShortcut) << "Translation not found for key:" << key << "in appId:" << appId;
     return key; // Fallback to key
 }
 

--- a/src/plugin-qt/shortcut/src/main.cpp
+++ b/src/plugin-qt/shortcut/src/main.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "shortcutlogging.h"
+
 #include <QGuiApplication>
 #include <QDebug>
 
@@ -27,7 +29,7 @@ int main(int argc, char *argv[])
     // Create and initialize ShortcutManager
     auto *shortcutManager = new ShortcutManager(&a);
     if (!shortcutManager->init()) {
-        qCritical() << "Failed to initialize ShortcutManager";
+        qCCritical(logShortcut) << "Failed to initialize ShortcutManager";
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- add the `dde.services.shortcut` Qt logging category for the shortcut plugin
- migrate 237 plugin and debug-runner log calls to the categorized `qC*` macros
- allow shortcut logs to be filtered independently inside the grouped service process

## Test plan
- `cmake --build build --target plugin-dde-shortcut dde-shortcut-debug -j2`
- `ctest --test-dir build -R "^shortcut-" --output-on-failure`
- verify runtime output contains `[dde.services.shortcut]`
- verify `QT_LOGGING_RULES="dde.services.shortcut=false"` suppresses the category

## Summary by Sourcery

Enhancements:
- Add a shared logging category definition for the shortcut service/plugin and wire it into all shortcut-related components.