### PR TITLE
fix: resolve custom shortcut conflicts during reset

### DIFF
--- a/src/plugin-qt/shortcut/src/config/configloader.cpp
+++ b/src/plugin-qt/shortcut/src/config/configloader.cpp
@@ -123,7 +123,8 @@ QStringList ConfigLoader::resettableHotkeyIds() const
     for (const KeyConfig &key : m_keys) {
         // Runtime custom shortcuts are created from an empty DConfig template.
         // Resetting their hotkeys would therefore clear the user-defined binding
-        // instead of restoring a meaningful default.
+        // instead of restoring a meaningful default. KeybindingManager clears
+        // only custom hotkeys that conflict with a restored built-in default.
         if (!key.modifiable || key.category == QLatin1String(CategoryKey::Custom))
             continue;
         DConfig *config = m_configs.value(key.subPath);
@@ -137,17 +138,29 @@ QStringList ConfigLoader::resettableHotkeyIds() const
     return ids;
 }
 
-void ConfigLoader::resetHotkeys(const QStringList &ids)
+QList<KeyConfig> ConfigLoader::resetHotkeys(const QStringList &ids)
 {
-    // DConfig emits valueChanged after reset; do not reload or emit keyConfigChanged here.
+    QList<KeyConfig> resetConfigs;
+
+    // reset() is synchronous. Read the restored value immediately so Reset
+    // can resolve conflicts in the same call instead of waiting for the later
+    // DConfig valueChanged signal.
     for (const QString &id : ids) {
         DConfig *config = m_configs.value(id);
         if (config && config->isValid() && !config->isReadOnly(QStringLiteral("hotkeys"))) {
             config->reset("hotkeys");
+            if (!config->isDefaultValue(QStringLiteral("hotkeys")))
+                qCWarning(logShortcut) << "ConfigLoader: hotkeys did not reset to default:" << id;
+
+            KeyConfig resetConfig;
+            if (reloadKeyConfig(id, &resetConfig))
+                resetConfigs.append(resetConfig);
         } else {
             qCWarning(logShortcut) << "ConfigLoader: hotkeys can not be reset:" << id;
         }
     }
+
+    return resetConfigs;
 }
 
 bool ConfigLoader::reloadKeyConfig(const QString &id, KeyConfig *result)

--- a/src/plugin-qt/shortcut/src/config/configloader.h
+++ b/src/plugin-qt/shortcut/src/config/configloader.h
@@ -30,7 +30,7 @@ public:
     void scanForConfigs();
     void reload();
     QStringList resettableHotkeyIds() const;
-    void resetHotkeys(const QStringList &ids);
+    QList<KeyConfig> resetHotkeys(const QStringList &ids);
     bool reloadKeyConfig(const QString &id, KeyConfig *result = nullptr);
     bool updateValue(const QString &id, const QString &key, const QVariant &value);
     bool canUpdateValue(const QString &id) const;

--- a/src/plugin-qt/shortcut/src/core/customshortcuttransaction.cpp
+++ b/src/plugin-qt/shortcut/src/core/customshortcuttransaction.cpp
@@ -22,11 +22,51 @@ void appendUniqueId(QStringList &ids, const QString &id)
 } // namespace
 
 // Creates a transaction for one prepared custom shortcut change.
-KeybindingManager::CustomShortcutTransaction::CustomShortcutTransaction(
-        KeybindingManager *manager, const CustomShortcutChange &change)
+KeybindingManager::CustomShortcutTransaction::CustomShortcutTransaction(KeybindingManager *manager, const CustomShortcutChange &change)
     : m_manager(manager)
     , m_change(change)
 {
+}
+
+// Each transaction restores its own state on failure. Reset only reports the
+// failure and does not add cross-component recovery.
+void KeybindingManager::CustomShortcutTransaction::clearConflictingHotkeys(KeybindingManager *manager, const QSet<QString> &reservedHotkeys)
+{
+    const QList<KeyConfig> configs = manager->m_keyConfigsMap.values();
+    for (const KeyConfig &oldConfig : configs) {
+        if (!manager->isRuntimeCustomShortcut(oldConfig))
+            continue;
+
+        KeyConfig newConfig = oldConfig;
+        newConfig.hotkeys.removeIf([&reservedHotkeys](const QString &hotkey) {
+            return reservedHotkeys.contains(hotkey);
+        });
+        if (newConfig.hotkeys == oldConfig.hotkeys)
+            continue;
+
+        CustomShortcutChange change;
+        change.hasOldTarget = true;
+        change.oldTarget = oldConfig;
+        change.newTarget = newConfig;
+
+        CustomShortcutTransaction transaction(manager, change);
+        if (!transaction.applyRuntime()) {
+            qCWarning(logShortcut) << "Reset: failed to clear custom shortcut conflict at runtime:"
+                                   << "id:" << oldConfig.getId()
+                                   << "old hotkeys:" << oldConfig.hotkeys
+                                   << "target hotkeys:" << newConfig.hotkeys;
+            return;
+        }
+        if (!transaction.persistModify()) {
+            qCWarning(logShortcut) << "Reset: failed to persist custom shortcut conflict cleanup:"
+                                   << "id:" << oldConfig.getId()
+                                   << "old hotkeys:" << oldConfig.hotkeys
+                                   << "target hotkeys:" << newConfig.hotkeys;
+            return;
+        }
+
+        transaction.publish();
+    }
 }
 
 // Applies runtime bindings and rolls back if registration or commit fails.

--- a/src/plugin-qt/shortcut/src/core/customshortcuttransaction.h
+++ b/src/plugin-qt/shortcut/src/core/customshortcuttransaction.h
@@ -6,13 +6,16 @@
 
 #include "keybindingmanager.h"
 
+#include <QSet>
 #include <QStringList>
 
-// Handles apply, persist, publish, and rollback for one custom shortcut change.
+// Handles transactional runtime and persistence changes for custom shortcuts.
 class KeybindingManager::CustomShortcutTransaction
 {
 public:
     CustomShortcutTransaction(KeybindingManager *manager, const CustomShortcutChange &change);
+
+    static void clearConflictingHotkeys(KeybindingManager *manager, const QSet<QString> &reservedHotkeys);
 
     bool applyRuntime();
     bool persistAdd();

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -1125,6 +1125,8 @@ void KeybindingManager::Reset()
         toRestore.append(id);
     }
 
+    // Release every reset target first so restored defaults cannot conflict
+    // with another built-in's stale binding.
     if (!m_keyHandler->commitSync()) {
         qCWarning(logShortcut) << "Reset: failed to commit unregistering existing hotkeys";
         for (const QString &id : std::as_const(toRestore)) {
@@ -1136,7 +1138,30 @@ void KeybindingManager::Reset()
         return;
     }
 
-    m_loader->resetHotkeys(resetIds);
+    const QSet<QString> resetIdSet(resetIds.begin(), resetIds.end());
+    m_resetInProgressIds.unite(resetIdSet);
+
+    QSet<QString> restoredHotkeys;
+    QList<KeyConfig> resetConfigs = m_loader->resetHotkeys(resetIds);
+    for (KeyConfig &config : resetConfigs) {
+        config.hotkeys = normalizeHotkeys(config.hotkeys);
+        restoredHotkeys.unite(QSet<QString>(config.hotkeys.begin(), config.hotkeys.end()));
+    }
+
+    CustomShortcutTransaction::clearConflictingHotkeys(this, restoredHotkeys);
+
+    // Reuse the normal DConfig change path now that custom conflicts are gone.
+    // Removing one id at a time keeps the remaining delayed reset signals
+    // suppressed while commitSync() runs its nested event loop.
+    for (const KeyConfig &config : std::as_const(resetConfigs)) {
+        // onConfigRemoved() removes the id from this set. Do not resurrect a
+        // config deleted while commitSync() was running its nested event loop.
+        if (!m_resetInProgressIds.remove(config.getId()))
+            continue;
+        onKeyConfigChanged(config);
+    }
+
+    m_resetInProgressIds.subtract(resetIdSet);
 }
 
 void KeybindingManager::onKeyConfigAdded(const KeyConfig &loadedConfig)
@@ -1158,12 +1183,18 @@ void KeybindingManager::onKeyConfigAdded(const KeyConfig &loadedConfig)
 
 void KeybindingManager::onKeyConfigChanged(const KeyConfig &loadedConfig)
 {
-    if (!m_keyConfigsMap.contains(loadedConfig.getId())) {
-        onKeyConfigAdded(loadedConfig);
+    // Reset already read and applied these values synchronously. Ignore the
+    // delayed DConfig notification while the transaction is still running.
+    if (m_resetInProgressIds.contains(loadedConfig.getId()))
         return;
-    }
+
     KeyConfig config = loadedConfig;
     config.hotkeys = normalizeHotkeys(config.hotkeys);
+    if (!m_keyConfigsMap.contains(config.getId())) {
+        onKeyConfigAdded(config);
+        return;
+    }
+
     const KeyConfig oldConfig = m_keyConfigsMap.value(config.getId());
     if (oldConfig == config) {
         if (config.canRegister() && !m_activeShortcutIds.contains(config.getId())) {
@@ -1206,6 +1237,7 @@ void KeybindingManager::onKeyConfigChanged(const KeyConfig &loadedConfig)
 
 void KeybindingManager::onConfigRemoved(const QString &id)
 {
+    m_resetInProgressIds.remove(id);
     if (m_keyConfigsMap.contains(id)) {
         m_keyConfigsMap.remove(id);
         const bool wasActive = m_activeShortcutIds.contains(id);

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -180,6 +180,7 @@ private:
     // id(shortcutId) -> KeyConfig
     QMap<QString, KeyConfig> m_keyConfigsMap;
     QSet<QString> m_activeShortcutIds;
+    QSet<QString> m_resetInProgressIds;
     bool m_isWayland = false;
 };
 


### PR DESCRIPTION
## Summary

- restore built-in shortcut defaults synchronously during Reset
- remove conflicting runtime custom shortcut bindings transactionally
- suppress delayed duplicate DConfig notifications during reset processing

## Test plan

- `git diff --check`
- `cmake --build build --target plugin-dde-shortcut -j2`

Pms: BUG-372049

## Summary by Sourcery

Ensure shortcut reset restores built-in defaults synchronously while resolving conflicts with runtime custom shortcuts and suppressing redundant configuration change processing.

Bug Fixes:
- Clear runtime custom shortcut hotkeys that conflict with restored built-in defaults during reset.
- Prevent delayed DConfig notifications from re-applying or resurrecting shortcut configurations while a reset transaction is in progress.

Enhancements:
- Make resetHotkeys return the restored key configurations so reset logic can operate on them immediately.
- Track reset-in-progress shortcut IDs to coordinate runtime state updates and config removal safely.