### PR TITLE
fix: align default window switching shortcuts

### DIFF
--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
@@ -34,8 +34,7 @@
         },
         "hotkeys": {
             "value": [
-                "Shift+Meta+Tab",
-                "Shift+Alt+Tab"
+                "Alt+Shift+Tab"
             ],
             "serial": 1,
             "flags": [],

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
@@ -34,10 +34,9 @@
         },
         "hotkeys": {
             "value": [
-                "Meta+`",
                 "Alt+`"
             ],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
@@ -34,10 +34,9 @@
         },
         "hotkeys": {
             "value": [
-                "Shift+Meta+`",
-                "Shift+Alt+`"
+                "Alt+Shift+~"
             ],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.wm-switcher/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.wm-switcher/org.deepin.shortcut.json
@@ -34,10 +34,10 @@
     },
     "hotkeys": {
       "value": [
-        "Ctrl+Meta+Tab"
+        "Shift+Meta+Tab"
       ],
       "permissions": "readwrite",
-      "serial": 0,
+      "serial": 1,
       "flags": [],
       "name": "hotkeys",
       "name[zh_CN]": "快捷键组合",


### PR DESCRIPTION
## Summary
- Align four window-switching shortcut configurations with the desktop defaults.
- Remove obsolete alternative bindings and correct reverse/window-effects combinations.
- Set the updated hotkey serial values to 1.

## Test plan
- Validate all modified JSON files with jq.
- Run git diff --check.

Pms: BUG-372017

## Summary by Sourcery

Align window-switching shortcut configurations with desktop defaults and clean up obsolete bindings.

Bug Fixes:
- Correct window-switching shortcut bindings to match expected desktop behavior and remove incorrect reverse/effects combinations.

Enhancements:
- Normalize hotkey configuration for four window-switching actions and reset their serial values for consistency across shortcut definitions.