### PR TITLE
fix: complete Traditional Chinese shortcut translations

### DIFF
--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
@@ -1,123 +1,183 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-<context>
+<TS version="2.1" language="zh_HK">
+  <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
-        <source>Clipboard</source>
-        <translation type="unfinished"></translation>
+      <source>Clipboard</source>
+      <translation>剪貼簿</translation>
     </message>
     <message>
-        <source>Lock screen</source>
-        <translation type="unfinished"></translation>
+      <source>Lock screen</source>
+      <translation>鎖定屏幕</translation>
     </message>
     <message>
-        <source>Notification Center</source>
-        <translation type="unfinished"></translation>
+      <source>Notification Center</source>
+      <translation>通知中心</translation>
     </message>
     <message>
-        <source>Shutdown interface</source>
-        <translation type="unfinished"></translation>
+      <source>Shutdown interface</source>
+      <translation>關機介面</translation>
     </message>
     <message>
-        <source>Terminal Quake Window</source>
-        <translation type="unfinished"></translation>
+      <source>Terminal Quake Window</source>
+      <translation>雷神終端機</translation>
     </message>
     <message>
-        <source>launcher</source>
-        <translation type="unfinished"></translation>
+      <source>launcher</source>
+      <translation>啟動器</translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
+      <source>Cancel Maximize Window</source>
+      <translation>取消最大化視窗</translation>
     </message>
     <message>
-        <source>Close Window</source>
-        <translation type="unfinished"></translation>
+      <source>Close Window</source>
+      <translation>關閉視窗</translation>
     </message>
     <message>
-        <source>Maximize Window</source>
-        <translation type="unfinished"></translation>
+      <source>Maximize Window</source>
+      <translation>最大化視窗</translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
+      <source>Show Desktop</source>
+      <translation>顯示桌面</translation>
     </message>
     <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
+      <source>Show Window Menu</source>
+      <translation>顯示視窗選單</translation>
     </message>
     <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
+      <source>Toggle Multitask View</source>
+      <translation>切換多工檢視</translation>
     </message>
     <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
+      <source>Delay Screenshot</source>
+      <translation>延時截圖</translation>
     </message>
     <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
+      <source>File Manager</source>
+      <translation>檔案管理員</translation>
     </message>
     <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
+      <source>Fullscreen Screenshot</source>
+      <translation>全屏截圖</translation>
     </message>
     <message>
-        <source>Show Desktop</source>
-        <translation type="unfinished"></translation>
+      <source>Global Search</source>
+      <translation>全域搜尋</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
-        <translation type="unfinished"></translation>
+      <source>Screenshot</source>
+      <translation>截圖</translation>
     </message>
     <message>
-        <source>Toggle Multitask View</source>
-        <translation type="unfinished"></translation>
+      <source>System Monitor</source>
+      <translation>系統監視器</translation>
     </message>
     <message>
-        <source>Delay Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Window Screenshot</source>
+      <translation>視窗截圖</translation>
     </message>
     <message>
-        <source>File Manager</source>
-        <translation type="unfinished"></translation>
+      <source>OCR Screenshot</source>
+      <translation>OCR 截圖</translation>
     </message>
     <message>
-        <source>Fullscreen Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>System</source>
+      <translation>系統</translation>
     </message>
     <message>
-        <source>Global Search</source>
-        <translation type="unfinished"></translation>
+      <source>Window</source>
+      <translation>視窗</translation>
     </message>
     <message>
-        <source>Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Workspace</source>
+      <translation>工作區</translation>
     </message>
     <message>
-        <source>System Monitor</source>
-        <translation type="unfinished"></translation>
+      <source>AssistiveTools</source>
+      <translation>輔助工具</translation>
     </message>
     <message>
-        <source>Window Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Minimize Window</source>
+      <translation>最小化視窗</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Move Window</source>
+      <translation>移動視窗</translation>
     </message>
     <message>
-        <source>System</source>
-        <translation type="unfinished"></translation>
+      <source>Move to Left Workspace</source>
+      <translation>移至左側工作區</translation>
     </message>
     <message>
-        <source>Window</source>
-        <translation type="unfinished"></translation>
+      <source>Move to Right Workspace</source>
+      <translation>移至右側工作區</translation>
     </message>
     <message>
-        <source>Workspace</source>
-        <translation type="unfinished"></translation>
+      <source>None</source>
+      <translation>無</translation>
     </message>
-</context>
+    <message>
+      <source>Resize Window</source>
+      <translation>調整視窗大小</translation>
+    </message>
+    <message>
+      <source>Screen Recorder</source>
+      <translation>屏幕錄影</translation>
+    </message>
+    <message>
+      <source>Scrollshot</source>
+      <translation>捲動截圖</translation>
+    </message>
+    <message>
+      <source>Switch Window Effects</source>
+      <translation>切換視窗特效</translation>
+    </message>
+    <message>
+      <source>Switch Windows</source>
+      <translation>切換視窗</translation>
+    </message>
+    <message>
+      <source>Switch Windows Reversely</source>
+      <translation>反向切換視窗</translation>
+    </message>
+    <message>
+      <source>Switch Windows of the Same Type</source>
+      <translation>切換同類型視窗</translation>
+    </message>
+    <message>
+      <source>Switch Windows of the Same Type Reversely</source>
+      <translation>反向切換同類型視窗</translation>
+    </message>
+    <message>
+      <source>Switch to Left Workspace</source>
+      <translation>切換至左側工作區</translation>
+    </message>
+    <message>
+      <source>Switch to Right Workspace</source>
+      <translation>切換至右側工作區</translation>
+    </message>
+    <message>
+      <source>Window Quick Tile Left</source>
+      <translation>視窗快速平鋪至左側</translation>
+    </message>
+    <message>
+      <source>Window Quick Tile Right</source>
+      <translation>視窗快速平鋪至右側</translation>
+    </message>
+    <message>
+      <source>Zoom In</source>
+      <translation>放大屏幕</translation>
+    </message>
+    <message>
+      <source>Zoom Out</source>
+      <translation>縮小屏幕</translation>
+    </message>
+    <message>
+      <source>Zoom to Actual Size</source>
+      <translation>重設屏幕縮放</translation>
+    </message>
+  </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
@@ -1,123 +1,183 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-<context>
+<TS version="2.1" language="zh_TW">
+  <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
-        <source>Clipboard</source>
-        <translation type="unfinished"></translation>
+      <source>Clipboard</source>
+      <translation>剪貼簿</translation>
     </message>
     <message>
-        <source>Lock screen</source>
-        <translation type="unfinished"></translation>
+      <source>Lock screen</source>
+      <translation>鎖定螢幕</translation>
     </message>
     <message>
-        <source>Notification Center</source>
-        <translation type="unfinished"></translation>
+      <source>Notification Center</source>
+      <translation>通知中心</translation>
     </message>
     <message>
-        <source>Shutdown interface</source>
-        <translation type="unfinished"></translation>
+      <source>Shutdown interface</source>
+      <translation>關機介面</translation>
     </message>
     <message>
-        <source>Terminal Quake Window</source>
-        <translation type="unfinished"></translation>
+      <source>Terminal Quake Window</source>
+      <translation>雷神終端機</translation>
     </message>
     <message>
-        <source>launcher</source>
-        <translation type="unfinished"></translation>
+      <source>launcher</source>
+      <translation>啟動器</translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
+      <source>Cancel Maximize Window</source>
+      <translation>取消最大化視窗</translation>
     </message>
     <message>
-        <source>Close Window</source>
-        <translation type="unfinished"></translation>
+      <source>Close Window</source>
+      <translation>關閉視窗</translation>
     </message>
     <message>
-        <source>Maximize Window</source>
-        <translation type="unfinished"></translation>
+      <source>Maximize Window</source>
+      <translation>最大化視窗</translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
+      <source>Show Desktop</source>
+      <translation>顯示桌面</translation>
     </message>
     <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
+      <source>Show Window Menu</source>
+      <translation>顯示視窗選單</translation>
     </message>
     <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
+      <source>Toggle Multitask View</source>
+      <translation>切換多工檢視</translation>
     </message>
     <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
+      <source>Delay Screenshot</source>
+      <translation>延遲截圖</translation>
     </message>
     <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
+      <source>File Manager</source>
+      <translation>檔案管理員</translation>
     </message>
     <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
+      <source>Fullscreen Screenshot</source>
+      <translation>全螢幕截圖</translation>
     </message>
     <message>
-        <source>Show Desktop</source>
-        <translation type="unfinished"></translation>
+      <source>Global Search</source>
+      <translation>全域搜尋</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
-        <translation type="unfinished"></translation>
+      <source>Screenshot</source>
+      <translation>截圖</translation>
     </message>
     <message>
-        <source>Toggle Multitask View</source>
-        <translation type="unfinished"></translation>
+      <source>System Monitor</source>
+      <translation>系統監視器</translation>
     </message>
     <message>
-        <source>Delay Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Window Screenshot</source>
+      <translation>視窗截圖</translation>
     </message>
     <message>
-        <source>File Manager</source>
-        <translation type="unfinished"></translation>
+      <source>OCR Screenshot</source>
+      <translation>OCR 截圖</translation>
     </message>
     <message>
-        <source>Fullscreen Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>System</source>
+      <translation>系統</translation>
     </message>
     <message>
-        <source>Global Search</source>
-        <translation type="unfinished"></translation>
+      <source>Window</source>
+      <translation>視窗</translation>
     </message>
     <message>
-        <source>Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Workspace</source>
+      <translation>工作區</translation>
     </message>
     <message>
-        <source>System Monitor</source>
-        <translation type="unfinished"></translation>
+      <source>AssistiveTools</source>
+      <translation>輔助工具</translation>
     </message>
     <message>
-        <source>Window Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Minimize Window</source>
+      <translation>最小化視窗</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
-        <translation type="unfinished"></translation>
+      <source>Move Window</source>
+      <translation>移動視窗</translation>
     </message>
     <message>
-        <source>System</source>
-        <translation type="unfinished"></translation>
+      <source>Move to Left Workspace</source>
+      <translation>移至左側工作區</translation>
     </message>
     <message>
-        <source>Window</source>
-        <translation type="unfinished"></translation>
+      <source>Move to Right Workspace</source>
+      <translation>移至右側工作區</translation>
     </message>
     <message>
-        <source>Workspace</source>
-        <translation type="unfinished"></translation>
+      <source>None</source>
+      <translation>無</translation>
     </message>
-</context>
+    <message>
+      <source>Resize Window</source>
+      <translation>調整視窗大小</translation>
+    </message>
+    <message>
+      <source>Screen Recorder</source>
+      <translation>螢幕錄影</translation>
+    </message>
+    <message>
+      <source>Scrollshot</source>
+      <translation>捲動截圖</translation>
+    </message>
+    <message>
+      <source>Switch Window Effects</source>
+      <translation>切換視窗特效</translation>
+    </message>
+    <message>
+      <source>Switch Windows</source>
+      <translation>切換視窗</translation>
+    </message>
+    <message>
+      <source>Switch Windows Reversely</source>
+      <translation>反向切換視窗</translation>
+    </message>
+    <message>
+      <source>Switch Windows of the Same Type</source>
+      <translation>切換同類型視窗</translation>
+    </message>
+    <message>
+      <source>Switch Windows of the Same Type Reversely</source>
+      <translation>反向切換同類型視窗</translation>
+    </message>
+    <message>
+      <source>Switch to Left Workspace</source>
+      <translation>切換至左側工作區</translation>
+    </message>
+    <message>
+      <source>Switch to Right Workspace</source>
+      <translation>切換至右側工作區</translation>
+    </message>
+    <message>
+      <source>Window Quick Tile Left</source>
+      <translation>視窗快速平鋪至左側</translation>
+    </message>
+    <message>
+      <source>Window Quick Tile Right</source>
+      <translation>視窗快速平鋪至右側</translation>
+    </message>
+    <message>
+      <source>Zoom In</source>
+      <translation>放大螢幕</translation>
+    </message>
+    <message>
+      <source>Zoom Out</source>
+      <translation>縮小螢幕</translation>
+    </message>
+    <message>
+      <source>Zoom to Actual Size</source>
+      <translation>重設螢幕縮放</translation>
+    </message>
+  </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_HK.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_HK.ts
@@ -1,15 +1,227 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-<context>
+<TS version="2.1" language="zh_HK">
+  <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
-        <translation type="unfinished"></translation>
+      <source>Display switch</source>
+      <translation>切換多屏模式</translation>
     </message>
     <message>
-        <source>Default terminal</source>
-        <translation type="unfinished"></translation>
+      <source>Default terminal</source>
+      <translation>終端機</translation>
     </message>
-</context>
+    <message>
+      <source>Swipe down with four fingers</source>
+      <translation>四指向下</translation>
+    </message>
+    <message>
+      <source>Swipe down with three fingers</source>
+      <translation>三指向下</translation>
+    </message>
+    <message>
+      <source>Swipe left with four fingers</source>
+      <translation>四指向左</translation>
+    </message>
+    <message>
+      <source>Swipe left with three fingers</source>
+      <translation>三指向左</translation>
+    </message>
+    <message>
+      <source>Swipe right with four fingers</source>
+      <translation>四指向右</translation>
+    </message>
+    <message>
+      <source>Swipe right with three fingers</source>
+      <translation>三指向右</translation>
+    </message>
+    <message>
+      <source>Swipe up with four fingers</source>
+      <translation>四指向上</translation>
+    </message>
+    <message>
+      <source>Swipe up with three fingers</source>
+      <translation>三指向上</translation>
+    </message>
+    <message>
+      <source>Four-finger tap</source>
+      <translation>四指短按</translation>
+    </message>
+    <message>
+      <source>Three-finger tap</source>
+      <translation>三指短按</translation>
+    </message>
+    <message>
+      <source>This gesture action is not currently supported</source>
+      <translation>暫不支援此手勢動作</translation>
+    </message>
+    <message>
+      <source>Maximize window</source>
+      <translation>最大化視窗</translation>
+    </message>
+    <message>
+      <source>Restore window</source>
+      <translation>還原視窗</translation>
+    </message>
+    <message>
+      <source>Current window left split</source>
+      <translation>目前視窗靠左分割</translation>
+    </message>
+    <message>
+      <source>Current window right split</source>
+      <translation>目前視窗靠右分割</translation>
+    </message>
+    <message>
+      <source>Show multitasking view</source>
+      <translation>顯示多工檢視</translation>
+    </message>
+    <message>
+      <source>Hide multitasking view</source>
+      <translation>隱藏多工檢視</translation>
+    </message>
+    <message>
+      <source>Switch to previous workspace</source>
+      <translation>切換至上一個工作區</translation>
+    </message>
+    <message>
+      <source>Switch to next workspace</source>
+      <translation>切換至下一個工作區</translation>
+    </message>
+    <message>
+      <source>Show desktop</source>
+      <translation>顯示桌面</translation>
+    </message>
+    <message>
+      <source>Hide desktop</source>
+      <translation>隱藏桌面</translation>
+    </message>
+    <message>
+      <source>Show/hide grand search</source>
+      <translation>開啟/關閉全域搜尋</translation>
+    </message>
+    <message>
+      <source>Show/hide launcher</source>
+      <translation>開啟/關閉啟動器</translation>
+    </message>
+    <message>
+      <source>Show/hide clipboard</source>
+      <translation>開啟/關閉剪貼簿</translation>
+    </message>
+    <message>
+      <source>Show/hide notification center</source>
+      <translation>開啟/關閉通知中心</translation>
+    </message>
+    <message>
+      <source>Disable</source>
+      <translation>停用</translation>
+    </message>
+    <message>
+      <source>Custom</source>
+      <translation>自訂</translation>
+    </message>
+    <message>
+      <source>AssistiveTools</source>
+      <translation>輔助工具</translation>
+    </message>
+    <message>
+      <source>Text to Speech</source>
+      <translation>文字轉語音</translation>
+    </message>
+    <message>
+      <source>Speech to Text</source>
+      <translation>語音轉文字</translation>
+    </message>
+    <message>
+      <source>Translation</source>
+      <translation>文字翻譯</translation>
+    </message>
+    <message>
+      <source>None</source>
+      <translation>無</translation>
+    </message>
+    <message>
+      <source>System</source>
+      <translation>系統</translation>
+    </message>
+    <message>
+      <source>Notify</source>
+      <translation>通知服務處理</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 1</source>
+      <translation>切換至工作區 1</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 2</source>
+      <translation>切換至工作區 2</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 3</source>
+      <translation>切換至工作區 3</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 4</source>
+      <translation>切換至工作區 4</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 5</source>
+      <translation>切換至工作區 5</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 6</source>
+      <translation>切換至工作區 6</translation>
+    </message>
+    <message>
+      <source>Move window</source>
+      <translation>移動視窗</translation>
+    </message>
+    <message>
+      <source>Close window</source>
+      <translation>關閉視窗</translation>
+    </message>
+    <message>
+      <source>Show window menu</source>
+      <translation>開啟視窗選單</translation>
+    </message>
+    <message>
+      <source>Toggle multitasking view</source>
+      <translation>切換多工檢視</translation>
+    </message>
+    <message>
+      <source>Toggle FPS display</source>
+      <translation>切換畫面更新率顯示</translation>
+    </message>
+    <message>
+      <source>Lock screen</source>
+      <translation>鎖定屏幕</translation>
+    </message>
+    <message>
+      <source>Show shutdown menu</source>
+      <translation>顯示關機選單</translation>
+    </message>
+    <message>
+      <source>Quit</source>
+      <translation>結束</translation>
+    </message>
+    <message>
+      <source>Enter task switcher</source>
+      <translation>進入工作切換器</translation>
+    </message>
+    <message>
+      <source>Select next task</source>
+      <translation>選擇下一個工作</translation>
+    </message>
+    <message>
+      <source>Select previous task</source>
+      <translation>選擇上一個工作</translation>
+    </message>
+    <message>
+      <source>Select next window of current application</source>
+      <translation>選擇目前應用程式的下一個視窗</translation>
+    </message>
+    <message>
+      <source>Select previous window of current application</source>
+      <translation>選擇目前應用程式的上一個視窗</translation>
+    </message>
+  </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_TW.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_TW.ts
@@ -1,15 +1,227 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-<context>
+<TS version="2.1" language="zh_TW">
+  <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
-        <translation type="unfinished"></translation>
+      <source>Display switch</source>
+      <translation>切換多螢幕模式</translation>
     </message>
     <message>
-        <source>Default terminal</source>
-        <translation type="unfinished"></translation>
+      <source>Default terminal</source>
+      <translation>終端機</translation>
     </message>
-</context>
+    <message>
+      <source>Swipe down with four fingers</source>
+      <translation>四指向下滑動</translation>
+    </message>
+    <message>
+      <source>Swipe down with three fingers</source>
+      <translation>三指向下滑動</translation>
+    </message>
+    <message>
+      <source>Swipe left with four fingers</source>
+      <translation>四指向左滑動</translation>
+    </message>
+    <message>
+      <source>Swipe left with three fingers</source>
+      <translation>三指向左滑動</translation>
+    </message>
+    <message>
+      <source>Swipe right with four fingers</source>
+      <translation>四指向右滑動</translation>
+    </message>
+    <message>
+      <source>Swipe right with three fingers</source>
+      <translation>三指向右滑動</translation>
+    </message>
+    <message>
+      <source>Swipe up with four fingers</source>
+      <translation>四指向上滑動</translation>
+    </message>
+    <message>
+      <source>Swipe up with three fingers</source>
+      <translation>三指向上滑動</translation>
+    </message>
+    <message>
+      <source>Four-finger tap</source>
+      <translation>四指輕觸</translation>
+    </message>
+    <message>
+      <source>Three-finger tap</source>
+      <translation>三指輕觸</translation>
+    </message>
+    <message>
+      <source>This gesture action is not currently supported</source>
+      <translation>目前不支援此手勢動作</translation>
+    </message>
+    <message>
+      <source>Maximize window</source>
+      <translation>最大化視窗</translation>
+    </message>
+    <message>
+      <source>Restore window</source>
+      <translation>還原視窗</translation>
+    </message>
+    <message>
+      <source>Current window left split</source>
+      <translation>目前視窗靠左分割</translation>
+    </message>
+    <message>
+      <source>Current window right split</source>
+      <translation>目前視窗靠右分割</translation>
+    </message>
+    <message>
+      <source>Show multitasking view</source>
+      <translation>顯示多工檢視</translation>
+    </message>
+    <message>
+      <source>Hide multitasking view</source>
+      <translation>隱藏多工檢視</translation>
+    </message>
+    <message>
+      <source>Switch to previous workspace</source>
+      <translation>切換至上一個工作區</translation>
+    </message>
+    <message>
+      <source>Switch to next workspace</source>
+      <translation>切換至下一個工作區</translation>
+    </message>
+    <message>
+      <source>Show desktop</source>
+      <translation>顯示桌面</translation>
+    </message>
+    <message>
+      <source>Hide desktop</source>
+      <translation>隱藏桌面</translation>
+    </message>
+    <message>
+      <source>Show/hide grand search</source>
+      <translation>開啟/關閉全域搜尋</translation>
+    </message>
+    <message>
+      <source>Show/hide launcher</source>
+      <translation>開啟/關閉啟動器</translation>
+    </message>
+    <message>
+      <source>Show/hide clipboard</source>
+      <translation>開啟/關閉剪貼簿</translation>
+    </message>
+    <message>
+      <source>Show/hide notification center</source>
+      <translation>開啟/關閉通知中心</translation>
+    </message>
+    <message>
+      <source>Disable</source>
+      <translation>停用</translation>
+    </message>
+    <message>
+      <source>Custom</source>
+      <translation>自訂</translation>
+    </message>
+    <message>
+      <source>AssistiveTools</source>
+      <translation>輔助工具</translation>
+    </message>
+    <message>
+      <source>Text to Speech</source>
+      <translation>文字轉語音</translation>
+    </message>
+    <message>
+      <source>Speech to Text</source>
+      <translation>語音轉文字</translation>
+    </message>
+    <message>
+      <source>Translation</source>
+      <translation>文字翻譯</translation>
+    </message>
+    <message>
+      <source>None</source>
+      <translation>無</translation>
+    </message>
+    <message>
+      <source>System</source>
+      <translation>系統</translation>
+    </message>
+    <message>
+      <source>Notify</source>
+      <translation>通知服務處理</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 1</source>
+      <translation>切換至工作區 1</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 2</source>
+      <translation>切換至工作區 2</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 3</source>
+      <translation>切換至工作區 3</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 4</source>
+      <translation>切換至工作區 4</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 5</source>
+      <translation>切換至工作區 5</translation>
+    </message>
+    <message>
+      <source>Switch to workspace 6</source>
+      <translation>切換至工作區 6</translation>
+    </message>
+    <message>
+      <source>Move window</source>
+      <translation>移動視窗</translation>
+    </message>
+    <message>
+      <source>Close window</source>
+      <translation>關閉視窗</translation>
+    </message>
+    <message>
+      <source>Show window menu</source>
+      <translation>開啟視窗選單</translation>
+    </message>
+    <message>
+      <source>Toggle multitasking view</source>
+      <translation>切換多工檢視</translation>
+    </message>
+    <message>
+      <source>Toggle FPS display</source>
+      <translation>切換畫面更新率顯示</translation>
+    </message>
+    <message>
+      <source>Lock screen</source>
+      <translation>鎖定螢幕</translation>
+    </message>
+    <message>
+      <source>Show shutdown menu</source>
+      <translation>顯示關機選單</translation>
+    </message>
+    <message>
+      <source>Quit</source>
+      <translation>結束</translation>
+    </message>
+    <message>
+      <source>Enter task switcher</source>
+      <translation>進入工作切換器</translation>
+    </message>
+    <message>
+      <source>Select next task</source>
+      <translation>選擇下一個工作</translation>
+    </message>
+    <message>
+      <source>Select previous task</source>
+      <translation>選擇上一個工作</translation>
+    </message>
+    <message>
+      <source>Select next window of current application</source>
+      <translation>選擇目前應用程式的下一個視窗</translation>
+    </message>
+    <message>
+      <source>Select previous window of current application</source>
+      <translation>選擇目前應用程式的上一個視窗</translation>
+    </message>
+  </context>
 </TS>


### PR DESCRIPTION
## Summary

- synchronize `zh_HK` and `zh_TW` keybinding catalogs with all 55 Simplified Chinese source entries
- synchronize application shortcut catalogs with all 44 Simplified Chinese source entries
- provide region-specific Traditional Chinese terminology and remove unfinished translations

## Test plan

- validate all four TS files with `xmllint`
- verify source entry count and order match the corresponding `zh_CN` catalogs
- compile all four catalogs with Qt 6 `lrelease`

## Summary by Sourcery

Complete and synchronize Traditional Chinese shortcut and keybinding translation catalogs for Hong Kong and Taiwan locales with the Simplified Chinese source entries.

Bug Fixes:
- Replace unfinished or missing Traditional Chinese shortcut translations with complete, region-appropriate terminology for zh_HK and zh_TW.

Enhancements:
- Add full Traditional Chinese translations for all keybinding actions in zh_HK and zh_TW catalogs, including touchpad gestures, window and workspace controls, and system features.
- Add full Traditional Chinese translations for all application shortcut actions in zh_HK and zh_TW catalogs, covering system utilities, screenshot modes, accessibility tools, and window management options.
- Set explicit TS language attributes for the Hong Kong and Taiwan shortcut translation files to match their respective locales.