### PR TITLE
fix: restore reverse same-application window switching

### DIFF
--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SHORTCUT_COMMON_SOURCES
     ${SHORTCUT_SRC_DIR}/backend/x11/modifierkeystate.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/modifierkeymonitor.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/x11shortcutpolicy.cpp
+    ${SHORTCUT_SRC_DIR}/backend/x11/x11wmaccelconverter.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/systemgestureproxy.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/x11gestureactionexecutor.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/x11gesturehandler.cpp

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
@@ -34,9 +34,9 @@
         },
         "hotkeys": {
             "value": [
-                "Alt+Shift+~"
+                "Alt+Shift+`"
             ],
-            "serial": 1,
+            "serial": 2,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/src/backend/x11/x11keyhandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11keyhandler.cpp
@@ -7,6 +7,7 @@
 #include "x11keyhandler.h"
 #include "modifierkeymonitor.h"
 #include "x11shortcutpolicy.h"
+#include "x11wmaccelconverter.h"
 #include "core/triggeractioncatalog.h"
 #include "core/qkeysequenceconverter.h"
 #include "core/physicalkeyalias.h"
@@ -472,7 +473,7 @@ bool X11KeyHandler::setWmShortcut(const QString &wmShortcutId, const QStringList
 {
     QJsonArray accels;
     for (const QString &hotkey : hotkeys)
-        accels.append(QKeySequenceConverter::qKeySequenceToXkb(hotkey));
+        accels.append(X11WmAccelConverter::toDaemonAccel(wmShortcutId, hotkey));
 
     const QString data = QString::fromUtf8(QJsonDocument(QJsonObject{
         {QStringLiteral("Id"), wmShortcutId},

--- a/src/plugin-qt/shortcut/src/backend/x11/x11wmaccelconverter.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11wmaccelconverter.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "x11wmaccelconverter.h"
+
+#include "core/qkeysequenceconverter.h"
+
+#include <QKeySequence>
+
+namespace X11WmAccelConverter {
+
+QString toDaemonAccel(const QString &wmShortcutId, const QString &hotkey)
+{
+    QString accel = QKeySequenceConverter::qKeySequenceToXkb(hotkey);
+    if (wmShortcutId != QLatin1String("switchGroupBackward"))
+        return accel;
+
+    const QKeySequence sequence = QKeySequence::fromString(hotkey, QKeySequence::PortableText);
+    if (sequence.isEmpty() || sequence.count() != 1)
+        return accel;
+
+    const QKeyCombination combination = sequence[0];
+    const bool shiftedGrave = combination.key() == Qt::Key_QuoteLeft
+            && combination.keyboardModifiers().testFlag(Qt::ShiftModifier);
+    const bool tilde = combination.key() == Qt::Key_AsciiTilde;
+    if (!shiftedGrave && !tilde)
+        return accel;
+
+    const QString keyName = QKeySequence(combination.key()).toString(QKeySequence::PortableText);
+    if (!keyName.isEmpty() && accel.endsWith(keyName)) {
+        accel.chop(keyName.size());
+        accel += QStringLiteral("asciitilde");
+    }
+    if (!accel.contains(QLatin1String("<Shift>")))
+        accel.prepend(QLatin1String("<Shift>"));
+    return accel;
+}
+
+}

--- a/src/plugin-qt/shortcut/src/backend/x11/x11wmaccelconverter.h
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11wmaccelconverter.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QString>
+
+namespace X11WmAccelConverter {
+
+// Convert the physical shortcut representation used by DConfig and the
+// control center to the legacy com.deepin.wm accelerator wire format.
+QString toDaemonAccel(const QString &wmShortcutId, const QString &hotkey);
+
+}

--- a/src/plugin-qt/shortcut/tests/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/tests/CMakeLists.txt
@@ -122,6 +122,24 @@ target_link_libraries(tst-x11shortcutpolicy PRIVATE
 
 add_test(NAME shortcut-x11shortcutpolicy COMMAND tst-x11shortcutpolicy)
 
+add_executable(tst-x11wmaccelconverter
+    tst_x11wmaccelconverter.cpp
+    ../src/backend/x11/x11wmaccelconverter.cpp
+    ../src/core/qkeysequenceconverter.cpp
+)
+
+target_include_directories(tst-x11wmaccelconverter PRIVATE
+    ../src
+)
+
+target_link_libraries(tst-x11wmaccelconverter PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Test
+)
+
+add_test(NAME shortcut-x11wmaccelconverter COMMAND tst-x11wmaccelconverter)
+
 add_executable(tst-x11recordmonitor
     tst_x11recordmonitor.cpp
     ../shortcutlogging.cpp

--- a/src/plugin-qt/shortcut/tests/tst_x11wmaccelconverter.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_x11wmaccelconverter.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "backend/x11/x11wmaccelconverter.h"
+
+#include <QTest>
+
+class TestX11WmAccelConverter : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void encodesReverseSameAppShortcutForKWin();
+    void encodesLegacyTildeRepresentationsForKWin();
+    void preservesOtherWindowManagerShortcuts();
+};
+
+void TestX11WmAccelConverter::encodesReverseSameAppShortcutForKWin()
+{
+    QCOMPARE(X11WmAccelConverter::toDaemonAccel(
+                     QStringLiteral("switchGroupBackward"),
+                     QStringLiteral("Alt+Shift+`")),
+             QStringLiteral("<Shift><Alt>asciitilde"));
+}
+
+void TestX11WmAccelConverter::encodesLegacyTildeRepresentationsForKWin()
+{
+    QCOMPARE(X11WmAccelConverter::toDaemonAccel(
+                     QStringLiteral("switchGroupBackward"),
+                     QStringLiteral("Alt+Shift+~")),
+             QStringLiteral("<Shift><Alt>asciitilde"));
+    QCOMPARE(X11WmAccelConverter::toDaemonAccel(
+                     QStringLiteral("switchGroupBackward"),
+                     QStringLiteral("Alt+~")),
+             QStringLiteral("<Shift><Alt>asciitilde"));
+}
+
+void TestX11WmAccelConverter::preservesOtherWindowManagerShortcuts()
+{
+    QCOMPARE(X11WmAccelConverter::toDaemonAccel(
+                     QStringLiteral("switchGroup"),
+                     QStringLiteral("Alt+`")),
+             QStringLiteral("<Alt>`"));
+    QCOMPARE(X11WmAccelConverter::toDaemonAccel(
+                     QStringLiteral("switchApplicationsBackward"),
+                     QStringLiteral("Alt+Shift+Tab")),
+             QStringLiteral("<Shift><Alt>Tab"));
+    QCOMPARE(X11WmAccelConverter::toDaemonAccel(
+                     QStringLiteral("switchGroupBackward"),
+                     QStringLiteral("Alt+`")),
+             QStringLiteral("<Alt>`"));
+}
+
+QTEST_GUILESS_MAIN(TestX11WmAccelConverter)
+
+#include "tst_x11wmaccelconverter.moc"


### PR DESCRIPTION
## Summary

- keep the control center shortcut displayed as the physical `Alt+Shift+grave` combination
- translate reverse same-application switching to KWin's legacy `asciitilde` accelerator
- preserve historical tilde representations without changing other KWin shortcuts

## Test plan

- build `plugin-dde-shortcut` and `tst-x11wmaccelconverter`
- run the shortcut converter and existing non-invasive shortcut tests
- verify `switchGroupBackward` registers as `<Shift><Alt>asciitilde` on X11
- verify physical `Alt+Shift+grave` triggers reverse same-application switching

Pms: BUG-372655

## Summary by Sourcery

Route X11 window manager shortcuts through a new accelerator converter to restore correct reverse same-application switching behavior while preserving existing shortcuts.

New Features:
- Introduce an X11 window manager accelerator converter module to translate DConfig/control center shortcut strings into the legacy com.deepin.wm accelerator format.

Bug Fixes:
- Ensure the reverse same-application shortcut (switchGroupBackward) is encoded as KWin's legacy asciitilde accelerator so Alt+Shift+` functions correctly again.

Enhancements:
- Wire the new accelerator converter into the X11 key handler so all window manager shortcuts use the centralized conversion logic.
- Add unit tests to verify reverse same-app shortcut encoding, legacy tilde representations, and non-regression for other window manager shortcuts.

Tests:
- Add a new tst-x11wmaccelconverter test executable and register it in CTest to cover accelerator conversion behavior for X11 window manager shortcuts.