### PR TITLE
fix: update shortcut display labels

### DIFF
--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.displayswitch/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.displayswitch/org.deepin.shortcut.json
@@ -13,12 +13,12 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Display switch",
-            "serial": 0,
+            "value": "Toggle multiple displays",
+            "serial": 1,
             "flags": [],
             "name": "displayName",
-            "name[zh_CN]": "切换显示模式",
-            "description": "切换显示模式快捷键",
+            "name[zh_CN]": "切换多屏模式",
+            "description": "切换多屏模式快捷键",
             "permissions": "",
             "visibility": "private"
         },
@@ -40,7 +40,7 @@
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",
-            "description": "切换显示模式快捷键组合",
+            "description": "切换多屏模式快捷键组合",
             "permissions": "readwrite",
             "visibility": "private"
         },
@@ -64,7 +64,7 @@
             "flags": [],
             "name": "triggerValue",
             "name[zh_CN]": "快捷键触发动作",
-            "description": "切换显示模式快捷键触发动作",
+            "description": "切换多屏模式快捷键触发动作",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.globalsearch/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.globalsearch/org.deepin.shortcut.json
@@ -13,8 +13,8 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Global Search",
-            "serial": 0,
+            "value": "Grand search",
+            "serial": 1,
             "flags": [],
             "name": "displayName",
             "name[zh_CN]": "全局搜索",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot-ocr/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.screenshot-ocr/org.deepin.shortcut.json
@@ -13,8 +13,8 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "OCR Screenshot",
-            "serial": 0,
+            "value": "OCR (Image to Text)",
+            "serial": 1,
             "flags": [],
             "name": "displayName",
             "name[zh_CN]": "图文识别",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-window-menu/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.show-window-menu/org.deepin.shortcut.json
@@ -13,8 +13,8 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Show Window Menu",
-            "serial": 0,
+            "value": "Open window menu",
+            "serial": 1,
             "flags": [],
             "name": "displayName",
             "name[zh_CN]": "打开窗口菜单",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
@@ -44,7 +44,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -64,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -80,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/src/core/gestureactioncatalog.cpp
+++ b/src/plugin-qt/shortcut/src/core/gestureactioncatalog.cpp
@@ -134,7 +134,7 @@ const QList<GestureActionMetadata> &GestureActionCatalog::metadata()
         {GestureActionId::RestoreWindow, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Restore window")},
         {GestureActionId::MoveWindow, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Move window")},
         {GestureActionId::CloseWindow, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Close window")},
-        {GestureActionId::ShowWindowMenu, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Show window menu")},
+        {GestureActionId::ShowWindowMenu, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Open window menu")},
         {GestureActionId::ShowMultitask, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Show multitasking view")},
         {GestureActionId::HideMultitask, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Hide multitasking view")},
         {GestureActionId::ToggleMultitask, QT_TRANSLATE_NOOP("org.deepin.dde.keybinding", "Toggle multitasking view")},

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_en.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -180,7 +180,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show window menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
## Summary
- Update shortcut display labels in DConfig and English translation catalogs.
- Align the runtime window-menu translation key.
- Increment serial only for DConfig fields whose value changed.

## Test plan
- Full build completed successfully.
- Shortcut unit tests passed; X11 integration tests requiring an X server were skipped by the environment.
- Chinese, Hong Kong, and Taiwan TS changes remain uncommitted for a follow-up change.

## Summary by Sourcery

Update shortcut display labels and align the window-menu action metadata with the new translation key for consistent runtime behavior.

Bug Fixes:
- Align the window menu gesture action with the updated translation key to ensure consistent labeling.

Enhancements:
- Refresh English shortcut display labels for display switching, global search, OCR screenshot, and window menu actions to be clearer and more consistent across DConfig and catalogs.