### PR TITLE
fix: sync shortcut translation catalogs

### DIFF
--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -121,6 +97,86 @@
     </message>
     <message>
         <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>Mostra l&apos;escriptori</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>Mostra el menú de la finestra</translation>
     </message>
     <message>
@@ -62,7 +64,7 @@
         <translation>Captura de la pantalla completa</translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation>Cerca global</translation>
     </message>
     <message>
@@ -78,7 +80,7 @@
         <translation>Captura de la finestra</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>Captura de reconeixement òptic de caràcters</translation>
     </message>
     <message>
@@ -95,87 +97,87 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>Näytä työpöytä</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>Näytä ikkunan valikot</translation>
     </message>
     <message>
@@ -62,7 +64,7 @@
         <translation>Kokonäytön kaappaus</translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation>Haku</translation>
     </message>
     <message>
@@ -78,7 +80,7 @@
         <translation>Ikkunan kaappaus</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>OCR-tekstintunnistus</translation>
     </message>
     <message>
@@ -95,87 +97,87 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>デスクトップを表示</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>ウィンドウメニューの表示</translation>
     </message>
     <message>
@@ -62,8 +64,8 @@
         <translation>画面全体のスクリーンショット</translation>
     </message>
     <message>
-        <source>Global Search</source>
-        <translation>Global Search</translation>
+        <source>Grand search</source>
+        <translation>Grand search</translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -78,104 +80,104 @@
         <translation>ウィンドウのスクリーンショット</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>OCRスクリーンショット</translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>Pokaż pulpit</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>Pokaż menu okna</translation>
     </message>
     <message>
@@ -62,7 +64,7 @@
         <translation>Zrzut pełnego ekranu</translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation>Wyszukiwanie globalne</translation>
     </message>
     <message>
@@ -78,7 +80,7 @@
         <translation>Zrzut okna</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>Zrzut OCR (Tekst z obrazu)</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>Mostrar Ambiente de Trabalho</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>Mostrar Menu da Janela</translation>
     </message>
     <message>
@@ -62,7 +64,7 @@
         <translation>Captura de Ecrã Completo</translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation>Pesquisa Global</translation>
     </message>
     <message>
@@ -78,7 +80,7 @@
         <translation>Captura de imagem da Janela</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>Captura de imagem OCR</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>Exibir área de trabalho</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>Exibir menu da janela</translation>
     </message>
     <message>
@@ -62,7 +64,7 @@
         <translation>Capturar tela inteira</translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation>Pesquisa global</translation>
     </message>
     <message>
@@ -78,7 +80,7 @@
         <translation>Capturar janela</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>Capturar texto por OCR</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -42,7 +44,7 @@
         <translation>Shfaqe Desktopin</translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation>Shfaq Menu Dritaresh</translation>
     </message>
     <message>
@@ -62,7 +64,7 @@
         <translation>Foto Ekrani Sa Krejt Ekrani</translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation>Kërkim Global</translation>
     </message>
     <message>
@@ -78,7 +80,7 @@
         <translation>Foto Ekrani Dritareje</translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation>Foto Ekrani OCR</translation>
     </message>
     <message>
@@ -95,87 +97,87 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
@@ -40,35 +40,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Window of Same App</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Previous Workspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Desktop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Window Menu</source>
+        <source>Open window menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -88,7 +64,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Global Search</source>
+        <source>Grand search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -104,7 +80,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OCR Screenshot</source>
+        <source>OCR (Image to Text)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -117,6 +93,90 @@
     </message>
     <message>
         <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resize Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screen Recorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrollshot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Window Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch Windows of the Same Type Reversely</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Left Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to Right Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Quick Tile Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zoom to Actual Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
@@ -45,7 +45,7 @@
     </message>
     <message>
         <source>Show Window Menu</source>
-        <translation>显示窗口菜单</translation>
+        <translation type="vanished">显示窗口菜单</translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -65,7 +65,7 @@
     </message>
     <message>
         <source>Global Search</source>
-        <translation>全局搜索</translation>
+        <translation type="vanished">全局搜索</translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -81,7 +81,7 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
-        <translation>OCR截图</translation>
+        <translation type="vanished">OCR截图</translation>
     </message>
     <message>
         <source>System</source>
@@ -178,6 +178,18 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>重置屏幕缩放</translation>
+    </message>
+    <message>
+        <source>Grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OCR (Image to Text)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -43,7 +45,7 @@
     </message>
     <message>
         <source>Show Window Menu</source>
-        <translation>顯示視窗選單</translation>
+        <translation type="vanished">顯示視窗選單</translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -63,7 +65,7 @@
     </message>
     <message>
         <source>Global Search</source>
-        <translation>全域搜尋</translation>
+        <translation type="vanished">全域搜尋</translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
-        <translation>OCR 截圖</translation>
+        <translation type="vanished">OCR 截圖</translation>
     </message>
     <message>
         <source>System</source>
@@ -176,6 +178,18 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>重設屏幕縮放</translation>
+    </message>
+    <message>
+        <source>Grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OCR (Image to Text)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -43,7 +45,7 @@
     </message>
     <message>
         <source>Show Window Menu</source>
-        <translation>顯示視窗選單</translation>
+        <translation type="vanished">顯示視窗選單</translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -63,7 +65,7 @@
     </message>
     <message>
         <source>Global Search</source>
-        <translation>全域搜尋</translation>
+        <translation type="vanished">全域搜尋</translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>OCR Screenshot</source>
-        <translation>OCR 截圖</translation>
+        <translation type="vanished">OCR 截圖</translation>
     </message>
     <message>
         <source>System</source>
@@ -176,6 +178,18 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>重設螢幕縮放</translation>
+    </message>
+    <message>
+        <source>Grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OCR (Image to Text)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ast.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ast.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_az.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_az.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_bg.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_bg.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_bo.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_bo.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ca.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ca.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Canviador de pantalla</translation>
     </message>
     <message>
@@ -178,7 +180,7 @@
         <translation>Tanca la finestra</translation>
     </message>
     <message>
-        <source>Show window menu</source>
+        <source>Open window menu</source>
         <translation>Mostra el menú de la finestra</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_cs.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_cs.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_da.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_da.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_de.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_de.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Bildschirm-Wechsel</translation>
     </message>
     <message>
@@ -178,7 +180,7 @@
         <translation>Fenster schließen</translation>
     </message>
     <message>
-        <source>Show window menu</source>
+        <source>Open window menu</source>
         <translation>Fenstermenü anzeigen</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_el.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_el.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_es.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_es.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Interruptor de pantalla</translation>
     </message>
     <message>
@@ -11,215 +13,215 @@
     </message>
     <message>
         <source>Swipe down with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe down with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This gesture action is not currently supported</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Maximize window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window left split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window right split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to previous workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to next workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide launcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide clipboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Translation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 2</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 3</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 4</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 5</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 6</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show window menu</source>
-        <translation type="unfinished"/>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle FPS display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show shutdown menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter task switcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_et.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_et.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_eu.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_eu.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_fa.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_fa.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_fi.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_fi.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Näytön vaihto</translation>
     </message>
     <message>
@@ -11,107 +13,107 @@
     </message>
     <message>
         <source>Swipe down with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe down with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This gesture action is not currently supported</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Maximize window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window left split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window right split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to previous workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to next workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide launcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide clipboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
@@ -119,19 +121,19 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Translation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
@@ -143,83 +145,83 @@
     </message>
     <message>
         <source>Notify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 2</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 3</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 4</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 5</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 6</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show window menu</source>
-        <translation type="unfinished"/>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle FPS display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show shutdown menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter task switcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_fr.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_fr.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_gl.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_gl.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_he.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_he.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hi.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hi.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hr.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hr.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hu.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hu.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hy.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_hy.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_id.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_id.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_it.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_it.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ja.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ja.ts
@@ -1,117 +1,119 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
-        <translation type="unfinished"/>
+        <source>Toggle multiple displays</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe down with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe down with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This gesture action is not currently supported</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Maximize window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window left split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window right split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to previous workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to next workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide launcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide clipboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
@@ -119,19 +121,19 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Translation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
@@ -143,83 +145,83 @@
     </message>
     <message>
         <source>Notify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 2</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 3</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 4</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 5</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 6</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show window menu</source>
-        <translation type="unfinished"/>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle FPS display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show shutdown menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter task switcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ka.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ka.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_kk.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_kk.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ko.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ko.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ky.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ky.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_lt.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_lt.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_lv.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_lv.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ms.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ms.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_nb.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_nb.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ne.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ne.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_nl.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_nl.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pa.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pa.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pl.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pl.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Przełącz ekran</translation>
     </message>
     <message>
@@ -178,7 +180,7 @@
         <translation>Zamknij okno</translation>
     </message>
     <message>
-        <source>Show window menu</source>
+        <source>Open window menu</source>
         <translation>Pokaż menu okna</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pt.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pt.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pt_BR.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_pt_BR.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Alternar tela</translation>
     </message>
     <message>
@@ -178,7 +180,7 @@
         <translation>Fechar janela</translation>
     </message>
     <message>
-        <source>Show window menu</source>
+        <source>Open window menu</source>
         <translation>Exibir menu da janela</translation>
     </message>
     <message>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ro.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ro.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ru.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ru.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sk.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sk.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sl.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sl.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sq.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sq.ts
@@ -1,8 +1,10 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation>Ndërrim ekrani</translation>
     </message>
     <message>
@@ -11,107 +13,107 @@
     </message>
     <message>
         <source>Swipe down with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe down with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe left with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe right with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with four fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Swipe up with three fingers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This gesture action is not currently supported</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Maximize window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window left split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Current window right split</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to previous workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to next workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hide desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide launcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide clipboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show/hide notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
@@ -119,19 +121,19 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text to Speech</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Speech to Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Translation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
@@ -143,83 +145,83 @@
     </message>
     <message>
         <source>Notify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 2</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 3</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 4</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 5</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to workspace 6</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show window menu</source>
-        <translation type="unfinished"/>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle FPS display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show shutdown menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Quit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter task switcher</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous task</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select next window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select previous window of current application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sr.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sr.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sv.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_sv.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_th.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_th.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_tr.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_tr.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ug.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_ug.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_uk.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_uk.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_vi.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_vi.ts
@@ -4,11 +4,223 @@
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
-        <source>Display switch</source>
+        <source>Toggle multiple displays</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default terminal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Four-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech to Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe down with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe left with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe right with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with four fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swipe up with three fingers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text to Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Three-finger tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This gesture action is not currently supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to workspace 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle FPS display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show shutdown menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter task switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous task</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select next window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select previous window of current application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window left split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current window right split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide grand search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide launcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show/hide notification center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_CN.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_CN.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
         <source>Display switch</source>
-        <translation>切换多屏模式</translation>
+        <translation type="vanished">切换多屏模式</translation>
     </message>
     <message>
         <source>Default terminal</source>
@@ -179,7 +181,7 @@
     </message>
     <message>
         <source>Show window menu</source>
-        <translation>打开窗口菜单</translation>
+        <translation type="vanished">打开窗口菜单</translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
@@ -220,6 +222,14 @@
     <message>
         <source>Select previous window of current application</source>
         <translation>选择当前应用的上一个窗口</translation>
+    </message>
+    <message>
+        <source>Toggle multiple displays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_HK.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
         <source>Display switch</source>
-        <translation>切換多屏模式</translation>
+        <translation type="vanished">切換多屏模式</translation>
     </message>
     <message>
         <source>Default terminal</source>
@@ -179,7 +181,7 @@
     </message>
     <message>
         <source>Show window menu</source>
-        <translation>開啟視窗選單</translation>
+        <translation type="vanished">開啟視窗選單</translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
@@ -220,6 +222,14 @@
     <message>
         <source>Select previous window of current application</source>
         <translation>選擇目前應用程式的上一個視窗</translation>
+    </message>
+    <message>
+        <source>Toggle multiple displays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_TW.ts
+++ b/src/plugin-qt/shortcut/translations/org.deepin.dde.keybinding_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>org.deepin.dde.keybinding</name>
     <message>
         <source>Display switch</source>
-        <translation>切換多螢幕模式</translation>
+        <translation type="vanished">切換多螢幕模式</translation>
     </message>
     <message>
         <source>Default terminal</source>
@@ -179,7 +181,7 @@
     </message>
     <message>
         <source>Show window menu</source>
-        <translation>開啟視窗選單</translation>
+        <translation type="vanished">開啟視窗選單</translation>
     </message>
     <message>
         <source>Toggle multitasking view</source>
@@ -220,6 +222,14 @@
     <message>
         <source>Select previous window of current application</source>
         <translation>選擇目前應用程式的上一個視窗</translation>
+    </message>
+    <message>
+        <source>Toggle multiple displays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open window menu</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

- synchronize the keybinding and DDE app shortcut TS catalogs after the label updates merged in #132
- keep every locale active source entries aligned with the English TS catalogs

## Test plan

- compared active source entries in all 53 locale catalogs with the English TS files for both translation groups
- validated all 108 changed TS files with xmllint
- compiled all 108 changed TS files with Qt 6 lrelease