### PR TITLE
fix: persist NumLock state on X11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+CMakeFiles/
 .vscode/
 *.user
 obj-x86_64-linux-gnu/

--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -53,6 +53,8 @@ set(SHORTCUT_COMMON_SOURCES
     ${SHORTCUT_SRC_DIR}/backend/x11/x11helper.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/modifierkeystate.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/modifierkeymonitor.cpp
+    ${SHORTCUT_SRC_DIR}/backend/x11/x11numlockstatecontroller.cpp
+    ${SHORTCUT_SRC_DIR}/backend/x11/x11numlockstatecontroller.h
     ${SHORTCUT_SRC_DIR}/backend/x11/x11shortcutpolicy.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/x11wmaccelconverter.cpp
     ${SHORTCUT_SRC_DIR}/backend/x11/systemgestureproxy.cpp
@@ -146,6 +148,12 @@ endforeach()
 dtk_add_config_meta_files(
     APPID "org.deepin.dde.keybinding"
     FILES "${CMAKE_CURRENT_SOURCE_DIR}/configs/org.deepin.shortcut.json"
+)
+
+# X11 NumLock state persistence owned by the shortcut service.
+dtk_add_config_meta_files(
+    APPID "org.deepin.dde.keybinding"
+    FILES "${CMAKE_CURRENT_SOURCE_DIR}/configs/org.deepin.dde.keybinding.keyboard.json"
 )
 
 foreach(SUBDIR_PATH ${GESTURE_CONFIG_SUBDIRS})

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.keyboard.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.keyboard.json
@@ -1,0 +1,36 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "capslockToggle": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "capslockToggle",
+            "name[zh_CN]": "大写锁定切换通知",
+            "description": "Control whether to show the CapsLock OSD",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "saveNumlockState": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "saveNumlockState",
+            "name[zh_CN]": "保存数字锁定状态",
+            "description": "Save NumLock state on X11",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "numlockState": {
+            "value": 2,
+            "serial": 0,
+            "flags": [],
+            "name": "numlockState",
+            "name[zh_CN]": "数字锁定状态",
+            "description": "NumLock state on X11. Enum values: 0=off, 1=on, 2=unknown; unknown defaults to off on laptops and on on desktops",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/src/plugin-qt/shortcut/src/backend/x11/x11keyhandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11keyhandler.cpp
@@ -1126,27 +1126,24 @@ void X11KeyHandler::setCapsLockState(bool on)
 
 void X11KeyHandler::setNumLockState(bool on)
 {
-    if (!isAvailable()) return;
+    if (!isAvailable() || !m_display)
+        return;
     
-    bool currentState = getNumLockState();
-    if (currentState == on) return;
-    
-    // Get NumLock keycode
-    xcb_keycode_t *keycodes = xcb_key_symbols_get_keycode(m_keySymbols, XK_Num_Lock);
-    if (!keycodes || keycodes[0] == XCB_NO_SYMBOL) {
-        if (keycodes) free(keycodes);
-        qCWarning(logShortcut) << "Failed to get NumLock keycode";
+    if (getNumLockState() == on)
+        return;
+
+    if (!m_numLockMask) {
+        qCWarning(logShortcut) << "X11KeyHandler: NumLock modifier mask is unavailable";
         return;
     }
-    
-    xcb_keycode_t keycode = keycodes[0];
-    free(keycodes);
-    
-    // Simulate key press and release
-    const xcb_window_t rootWindow = m_rootWindows.constFirst();
-    xcb_test_fake_input(m_connection, XCB_KEY_PRESS, keycode, XCB_CURRENT_TIME, rootWindow, 0, 0, 0);
-    xcb_test_fake_input(m_connection, XCB_KEY_RELEASE, keycode, XCB_CURRENT_TIME, rootWindow, 0, 0, 0);
-    xcb_flush(m_connection);
+
+    const unsigned int lockedModifiers = on ? m_numLockMask : 0;
+    if (!XkbLockModifiers(m_display, XkbUseCoreKbd,
+                          m_numLockMask, lockedModifiers)) {
+        qCWarning(logShortcut) << "X11KeyHandler: failed to set NumLock state through XKB";
+        return;
+    }
+    XFlush(m_display);
 }
 
 // ==================== Modifier Key Handler ====================

--- a/src/plugin-qt/shortcut/src/backend/x11/x11numlockstatecontroller.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11numlockstatecontroller.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "x11numlockstatecontroller.h"
+
+#include "backend/abstractkeyhandler.h"
+#include "shortcutlogging.h"
+
+#include <DConfig>
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QVariant>
+
+namespace {
+constexpr const char *kKeyboardConfigAppId = "org.deepin.dde.keybinding";
+constexpr const char *kKeyboardConfigName = "org.deepin.dde.keybinding.keyboard";
+constexpr const char *kLegacyKeyboardConfigAppId = "org.deepin.dde.daemon";
+constexpr const char *kLegacyKeyboardConfigName = "org.deepin.dde.daemon.keyboard";
+constexpr const char *kSaveNumLockStateKey = "saveNumlockState";
+constexpr const char *kNumLockStateKey = "numlockState";
+
+constexpr const char *kPowerService = "org.deepin.dde.Power1";
+constexpr const char *kPowerPath = "/org/deepin/dde/Power1";
+constexpr const char *kPowerInterface = "org.deepin.dde.Power1";
+constexpr const char *kHasBatteryProperty = "HasBattery";
+
+constexpr uint kNumLockOff = 0;
+constexpr uint kNumLockOn = 1;
+constexpr uint kNumLockUnknown = 2;
+}
+
+X11NumLockStateController::X11NumLockStateController(AbstractKeyHandler *keyHandler,
+                                                     QObject *parent)
+    : QObject(parent)
+    , m_keyHandler(keyHandler)
+{
+    if (!m_keyHandler) {
+        qCWarning(logShortcut) << "X11NumLockStateController: key handler is unavailable";
+        return;
+    }
+
+    m_lastState = state();
+    connect(m_keyHandler, &AbstractKeyHandler::numLockStateChanged,
+            this, &X11NumLockStateController::updateState);
+
+    m_keyboardConfig = Dtk::Core::DConfig::create(
+            QString::fromLatin1(kKeyboardConfigAppId),
+            QString::fromLatin1(kKeyboardConfigName),
+            QString(), this);
+    if (!m_keyboardConfig || !m_keyboardConfig->isValid()) {
+        qCWarning(logShortcut) << "X11NumLockStateController: keyboard config is unavailable";
+        return;
+    }
+
+    migrateLegacyState();
+    restoreState();
+}
+
+uint X11NumLockStateController::state() const
+{
+    return m_keyHandler && m_keyHandler->getNumLockState() ? kNumLockOn : kNumLockOff;
+}
+
+void X11NumLockStateController::setState(uint state)
+{
+    if (!m_keyHandler)
+        return;
+
+    const uint desiredState = state == kNumLockOff ? kNumLockOff : kNumLockOn;
+    m_keyHandler->setNumLockState(desiredState == kNumLockOn);
+
+    const uint actualState = this->state();
+    if (actualState != desiredState) {
+        qCWarning(logShortcut) << "X11NumLockStateController: failed to set NumLock state to"
+                               << desiredState << "; actual state is" << actualState;
+    }
+    updateState(actualState == kNumLockOn);
+}
+
+void X11NumLockStateController::migrateLegacyState()
+{
+    const QString stateKey = QString::fromLatin1(kNumLockStateKey);
+    const QString saveStateKey = QString::fromLatin1(kSaveNumLockStateKey);
+    bool ok = false;
+    const uint configuredState = m_keyboardConfig->value(stateKey).toUInt(&ok);
+    if (!ok || configuredState != kNumLockUnknown)
+        return;
+
+    auto *legacyConfig = Dtk::Core::DConfig::create(
+            QString::fromLatin1(kLegacyKeyboardConfigAppId),
+            QString::fromLatin1(kLegacyKeyboardConfigName),
+            QString(), this);
+    if (!legacyConfig || !legacyConfig->isValid()) {
+        if (legacyConfig)
+            legacyConfig->deleteLater();
+        return;
+    }
+
+    bool migrated = false;
+    const QVariant legacySaveState = legacyConfig->value(saveStateKey);
+    if (legacySaveState.isValid()) {
+        m_keyboardConfig->setValue(saveStateKey, legacySaveState.toBool());
+        migrated = true;
+    }
+
+    const uint legacyState = legacyConfig->value(stateKey).toUInt(&ok);
+    if (ok && (legacyState == kNumLockOff || legacyState == kNumLockOn)) {
+        m_keyboardConfig->setValue(stateKey, static_cast<int>(legacyState));
+        migrated = true;
+    }
+    if (migrated)
+        qCInfo(logShortcut) << "X11NumLockStateController: migrated legacy NumLock config";
+    legacyConfig->deleteLater();
+}
+
+void X11NumLockStateController::restoreState()
+{
+    const QString key = QString::fromLatin1(kNumLockStateKey);
+    const QVariant configuredValue = m_keyboardConfig->value(key);
+    bool ok = false;
+    const uint configuredState = configuredValue.toUInt(&ok);
+    const bool saveState = shouldSaveState();
+
+    uint desiredState = configuredState;
+    if (ok && configuredState == kNumLockUnknown) {
+        const bool laptop = hasBattery();
+        desiredState = laptop ? kNumLockOff : kNumLockOn;
+        qCInfo(logShortcut) << "X11NumLockStateController: no saved NumLock state; using"
+                            << (laptop ? "laptop default (off)" : "desktop default (on)");
+        if (saveState)
+            persistState(desiredState);
+    } else if (ok && (configuredState == kNumLockOff || configuredState == kNumLockOn)) {
+        if (!saveState) {
+            qCDebug(logShortcut) << "X11NumLockStateController: state persistence is disabled";
+            return;
+        }
+        qCInfo(logShortcut) << "X11NumLockStateController: restoring NumLock state:"
+                            << desiredState;
+    } else {
+        qCWarning(logShortcut) << "X11NumLockStateController: invalid saved NumLock state:"
+                               << configuredValue;
+        return;
+    }
+
+    m_keyHandler->setNumLockState(desiredState == kNumLockOn);
+    const uint actualState = state();
+    if (actualState != desiredState) {
+        qCWarning(logShortcut) << "X11NumLockStateController: failed to restore NumLock state to"
+                               << desiredState << "; actual state is" << actualState;
+    }
+    m_lastState = actualState;
+}
+
+void X11NumLockStateController::updateState(bool on)
+{
+    const uint state = on ? kNumLockOn : kNumLockOff;
+    if (m_lastState == state)
+        return;
+
+    m_lastState = state;
+    persistState(state);
+    emit stateChanged(on);
+}
+
+void X11NumLockStateController::persistState(uint state)
+{
+    if (!shouldSaveState())
+        return;
+
+    const uint normalizedState = state == kNumLockOn ? kNumLockOn : kNumLockOff;
+    const QString key = QString::fromLatin1(kNumLockStateKey);
+    bool ok = false;
+    const uint savedState = m_keyboardConfig->value(key).toUInt(&ok);
+    if (ok && savedState == normalizedState)
+        return;
+
+    m_keyboardConfig->setValue(key, static_cast<int>(normalizedState));
+}
+
+bool X11NumLockStateController::shouldSaveState() const
+{
+    return m_keyboardConfig && m_keyboardConfig->isValid()
+            && m_keyboardConfig->value(QString::fromLatin1(kSaveNumLockStateKey)).toBool();
+}
+
+bool X11NumLockStateController::hasBattery() const
+{
+    // Keep the legacy dde-daemon fallback: a failed battery query is treated
+    // as no battery, so the unknown NumLock state uses the desktop default.
+    QDBusInterface power(QString::fromLatin1(kPowerService),
+                         QString::fromLatin1(kPowerPath),
+                         QString::fromLatin1(kPowerInterface),
+                         QDBusConnection::systemBus());
+    if (!power.isValid()) {
+        qCWarning(logShortcut) << "X11NumLockStateController: failed to query HasBattery:"
+                               << power.lastError().message()
+                               << "; preserving legacy fallback and treating the device as having no battery";
+        return false;
+    }
+
+    const QVariant value = power.property(kHasBatteryProperty);
+    if (!value.isValid()) {
+        qCWarning(logShortcut) << "X11NumLockStateController: HasBattery property is unavailable;"
+                                  " preserving legacy fallback and treating the device as having no battery";
+        return false;
+    }
+    return value.toBool();
+}

--- a/src/plugin-qt/shortcut/src/backend/x11/x11numlockstatecontroller.h
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11numlockstatecontroller.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+
+class AbstractKeyHandler;
+
+namespace Dtk::Core {
+class DConfig;
+}
+
+class X11NumLockStateController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit X11NumLockStateController(AbstractKeyHandler *keyHandler,
+                                       QObject *parent = nullptr);
+
+    uint state() const;
+    void setState(uint state);
+
+signals:
+    void stateChanged(bool on);
+
+private:
+    void migrateLegacyState();
+    void restoreState();
+    void updateState(bool on);
+    void persistState(uint state);
+    bool shouldSaveState() const;
+    bool hasBattery() const;
+
+    AbstractKeyHandler *m_keyHandler = nullptr;
+    Dtk::Core::DConfig *m_keyboardConfig = nullptr;
+    uint m_lastState = 0;
+};

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -16,6 +16,7 @@
 #include "qkeysequenceconverter.h"
 #include "physicalkeyalias.h"
 #include "backend/x11/x11gestureactionexecutor.h"
+#include "backend/x11/x11numlockstatecontroller.h"
 
 #include <DGuiApplicationHelper>
 
@@ -302,13 +303,13 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
 
     // Connect signals from key handler
     connect(m_keyHandler, &AbstractKeyHandler::keyActivated, this, &KeybindingManager::onKeyActivated);
-    connect(m_keyHandler, &AbstractKeyHandler::numLockStateChanged,
-            this, &KeybindingManager::updateNumLockState);
     connect(m_keyHandler, &AbstractKeyHandler::capsLockStateChanged,
             this, &KeybindingManager::updateCapsLockState);
-    m_lastNumLockState = GetNumLockState();
     m_lastCapsLockState = GetCapsLockState();
     if (!m_isWayland) {
+        m_numLockStateController = new X11NumLockStateController(m_keyHandler, this);
+        connect(m_numLockStateController, &X11NumLockStateController::stateChanged,
+                this, &KeybindingManager::updateNumLockState);
         connect(m_keyHandler, &AbstractKeyHandler::captureStarted,
                 this, [this] { m_specialKeyHandler->setEnabled(false); });
         connect(m_keyHandler, &AbstractKeyHandler::captureKeyEvent,
@@ -320,6 +321,7 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
         connect(m_keyHandler, &AbstractKeyHandler::keymapChanged,
                 this, &KeybindingManager::onBackendKeymapChanged);
     }
+    m_lastNumLockState = GetNumLockState();
     
     // Connect signals from special key handler
     connect(m_specialKeyHandler, &SpecialKeyHandler::keyActivated, this, &KeybindingManager::onKeyActivated);
@@ -1521,6 +1523,8 @@ QString KeybindingManager::localizedNoHotkeyText() const
 
 uint KeybindingManager::GetNumLockState() const
 {
+    if (m_numLockStateController)
+        return m_numLockStateController->state();
     if (m_keyHandler) {
         return m_keyHandler->getNumLockState() ? 1 : 0;
     }
@@ -1537,6 +1541,22 @@ uint KeybindingManager::GetCapsLockState() const
 
 void KeybindingManager::SetNumLockState(uint state)
 {
+    if (m_numLockStateController) {
+        const uint oldState = GetNumLockState();
+        m_numLockStateController->setState(state);
+
+        const uint newState = GetNumLockState();
+        if (oldState != newState && m_executor
+                && !m_executor->executeCommand({
+                        QStringLiteral("/usr/bin/dde-shortcut-tool"),
+                        QStringLiteral("lockkey"),
+                        QStringLiteral("numlock"),
+                })) {
+            qCWarning(logShortcut) << "KeybindingManager: failed to launch NumLock OSD tool";
+        }
+        return;
+    }
+
     if (m_keyHandler) {
         uint oldState = GetNumLockState();
         m_keyHandler->setNumLockState(state != 0);

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -20,6 +20,8 @@ class AbstractKeyHandler;
 class SpecialKeyHandler;
 class TranslationManager;
 class X11GestureActionExecutor;
+class X11NumLockStateController;
+
 struct ShortcutInfo {
     QString id;
     QString displayName;
@@ -186,6 +188,7 @@ private:
     uint m_lastNumLockState = 0;
     uint m_lastCapsLockState = 0;
     bool m_isWayland = false;
+    X11NumLockStateController *m_numLockStateController = nullptr;
 };
 
 Q_DECLARE_METATYPE(QList<ShortcutInfo>)

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/constant.h
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/constant.h
@@ -57,18 +57,14 @@ constexpr const char *DSETTINGS_KEYBINDING_MEDIAKEY = "org.deepin.dde.daemon.key
 constexpr const char *DSETTINGS_KEYBINDING_WRAP_GNOME_WM = "org.deepin.dde.daemon.keybinding.wrap.gnome.wm";
 constexpr const char *DSETTINGS_KEYBINDING_ENABLE = "org.deepin.dde.daemon.keybinding.enable";
 constexpr const char *DSETTINGS_POWER = "org.deepin.dde.daemon.power";
-constexpr const char *DSETTINGS_KEYBOARD = "org.deepin.dde.daemon.keyboard";
 
 // Config Keys
 constexpr const char *KEY_WIRELESS_CONTROL_ENABLE = "wirelessControlEnable";
 constexpr const char *KEY_NEED_XRANDR_Q_DEVICES = "needXrandrQDevices";
 constexpr const char *KEY_DEVICE_MANAGER_CONTROL_ENABLE = "deviceManagerControlEnable";
-constexpr const char *KEY_NUM_LOCK_STATE = "numlockState";
-constexpr const char *KEY_SAVE_NUM_LOCK_STATE = "saveNumlockState";
 constexpr const char *KEY_SHORTCUT_SWITCH_LAYOUT = "shortcutSwitchLayout";
 
 // OSD related keys
-constexpr const char *KEY_SHOW_CAPS_LOCK_OSD = "capslockToggle";
 constexpr const char *KEY_OSD_ADJUST_VOLUME_STATE = "osdAdjustVolumeEnabled";
 constexpr const char *KEY_OSD_ADJUST_BRIGHTNESS_STATE = "osdAdjustBrightnessEnabled";
 

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/lockkeycontroller.cpp
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/lockkeycontroller.cpp
@@ -24,6 +24,17 @@
 DCORE_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
+namespace {
+constexpr const char *kKeyboardConfigAppId = "org.deepin.dde.keybinding";
+constexpr const char *kKeyboardConfigName = "org.deepin.dde.keybinding.keyboard";
+constexpr const char *kLegacyKeyboardConfigAppId = "org.deepin.dde.daemon";
+constexpr const char *kLegacyKeyboardConfigName = "org.deepin.dde.daemon.keyboard";
+constexpr const char *kCapsLockToggleKey = "capslockToggle";
+constexpr const char *kSaveNumLockStateKey = "saveNumlockState";
+constexpr const char *kNumLockStateKey = "numlockState";
+constexpr uint kNumLockUnknown = 2;
+}
+
 LockKeyController::LockKeyController(QObject *parent) 
     : BaseController(parent)
     , m_keyboardConfig(nullptr)
@@ -35,9 +46,11 @@ LockKeyController::LockKeyController(QObject *parent)
     // Detect session type
     m_isWayland = isWayland();
     
-    // Initialize keyboard configuration
-    m_keyboardConfig = DConfig::create("org.deepin.dde.daemon", 
-                                        "org.deepin.dde.daemon.keyboard", 
+    // Lock-key settings are owned and installed by the shortcut service.
+    // X11NumLockStateController normally owns NumLock persistence; this tool
+    // retains a compatibility write for mixed-version live upgrades.
+    m_keyboardConfig = DConfig::create(kKeyboardConfigAppId,
+                                        kKeyboardConfigName,
                                         "", this);
     if (!m_keyboardConfig || !m_keyboardConfig->isValid()) {
         qWarning() << "Keyboard config not available";
@@ -156,25 +169,52 @@ void LockKeyController::handleNumLockOSD()
         qWarning() << "Failed to query NumLock state";
         return;
     }
-    
-    // Check if we should save the state
-    bool shouldSave = false;
-    if (m_keyboardConfig && m_keyboardConfig->isValid()) {
-        QVariant saveValue = m_keyboardConfig->value("saveNumlockState");
-        shouldSave = saveValue.toBool();
-    }
-    
+
+    saveNumLockStateForUpgradeCompatibility(state);
+
     if (state == 1) { // NumLock On
-        if (shouldSave && m_keyboardConfig) {
-            m_keyboardConfig->setValue("numlockState", 1);
-        }
         showOSD("NumLockOn");
     } else { // NumLock Off
-        if (shouldSave && m_keyboardConfig) {
-            m_keyboardConfig->setValue("numlockState", 0);
-        }
         showOSD("NumLockOff");
     }
+}
+
+void LockKeyController::saveNumLockStateForUpgradeCompatibility(int state)
+{
+    if (m_isWayland || !m_keyboardConfig || !m_keyboardConfig->isValid())
+        return;
+
+    bool ok = false;
+    const uint configuredState = m_keyboardConfig->value(kNumLockStateKey).toUInt(&ok);
+    if (ok && configuredState == kNumLockUnknown) {
+        // During a live upgrade the old plugin can remain loaded while this
+        // helper has already been replaced. Preserve the legacy save switch
+        // before the new controller gets a chance to run its full migration.
+        auto *legacyConfig = DConfig::create(kLegacyKeyboardConfigAppId,
+                                             kLegacyKeyboardConfigName,
+                                             "", this);
+        if (legacyConfig && legacyConfig->isValid()) {
+            const QVariant legacySaveState = legacyConfig->value(kSaveNumLockStateKey);
+            if (legacySaveState.isValid())
+                m_keyboardConfig->setValue(kSaveNumLockStateKey,
+                                           legacySaveState.toBool());
+
+            bool legacyStateOk = false;
+            const uint legacyState = legacyConfig->value(kNumLockStateKey)
+                                             .toUInt(&legacyStateOk);
+            if (legacyStateOk && legacyState <= 1)
+                m_keyboardConfig->setValue(kNumLockStateKey,
+                                           static_cast<int>(legacyState));
+        }
+        if (legacyConfig)
+            legacyConfig->deleteLater();
+    }
+
+    if (!m_keyboardConfig->value(kSaveNumLockStateKey).toBool())
+        return;
+
+    if (!ok || configuredState != static_cast<uint>(state))
+        m_keyboardConfig->setValue(kNumLockStateKey, state);
 }
 
 int LockKeyController::queryCapsLockState()
@@ -201,7 +241,7 @@ bool LockKeyController::shouldShowCapsLockOSD()
         return true; // Show by default
     }
     
-    QVariant showValue = m_keyboardConfig->value("capslockToggle");
+    QVariant showValue = m_keyboardConfig->value(kCapsLockToggleKey);
     return showValue.toBool();
 }
 

--- a/src/plugin-qt/shortcut/tools/dde-shortcut-tool/lockkeycontroller.h
+++ b/src/plugin-qt/shortcut/tools/dde-shortcut-tool/lockkeycontroller.h
@@ -49,6 +49,7 @@ private:
     
     // NumLock handling
     void handleNumLockOSD();
+    void saveNumLockStateForUpgradeCompatibility(int state);
     
     // Query lock state (returns -1 on failure, 0 for off, 1 for on)
     int queryCapsLockState();


### PR DESCRIPTION
## Summary
- persist and restore NumLock state on X11 through a shortcut-owned DConfig, with legacy state and preference migration
- use XKB modifier locking to avoid synthetic startup key events while preserving OSD feedback for user-initiated changes
- leave Treeland state ownership to the compositor and retain helper compatibility during live package upgrades

## Test plan
- `cmake --build build --target plugin-dde-shortcut dde-shortcut-tool dde-shortcut-debug -j2`
- `ctest --test-dir build --output-on-failure -E shortcut-x11\\(recordmonitor\\|grabresilientshortcuts\\)`
- verify the DConfig JSON with `python3 -m json.tool`
- manually verify X11 state restoration does not show an OSD, while control-center and physical-key changes do

## Summary by Sourcery

Persist NumLock state on X11 at the shortcut service level, with migration from legacy settings and improved, non-synthetic modifier handling.

New Features:
- Introduce an X11 NumLock state controller that restores and persists NumLock across sessions based on user preference and device type (desktop vs laptop).

Bug Fixes:
- Avoid using synthetic key events to change NumLock on X11 by switching to XKB modifier locking, preventing unintended OSD behavior on startup.

Enhancements:
- Migrate NumLock-related configuration from legacy daemon settings to shortcut-owned DConfig, preserving behavior during live upgrades and keeping existing helpers compatible.
- Wire the keybinding manager to the new X11 NumLock controller so that NumLock state changes trigger the dedicated OSD tool instead of relying solely on the key handler.

Build:
- Register the new X11 NumLock state controller sources in the build and add a config meta file for the shortcut-owned keyboard DConfig.