### PR TITLE
fix: support legacy hardware shortcut events

### DIFF
--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -37,6 +37,10 @@ set(SHORTCUT_COMMON_SOURCES
     ${SHORTCUT_SRC_DIR}/core/triggeractioncatalog.cpp
     ${SHORTCUT_SRC_DIR}/core/gestureactioncatalog.cpp
     ${SHORTCUT_SRC_DIR}/core/gesturemanager.cpp
+    ${SHORTCUT_SRC_DIR}/core/crosschannelactivationguard.cpp
+    ${SHORTCUT_SRC_DIR}/core/crosschannelactivationguard.h
+    ${SHORTCUT_SRC_DIR}/core/sessionactivemonitor.cpp
+    ${SHORTCUT_SRC_DIR}/core/sessionactivemonitor.h
     ${SHORTCUT_SRC_DIR}/core/sessiongestureguard.cpp
     ${SHORTCUT_SRC_DIR}/core/qkeysequenceconverter.cpp
     ${SHORTCUT_SRC_DIR}/core/physicalkeyalias.cpp

--- a/src/plugin-qt/shortcut/DEVELOPER_GUIDE.md
+++ b/src/plugin-qt/shortcut/DEVELOPER_GUIDE.md
@@ -1279,7 +1279,7 @@ sudo evtest
 
 ```bash
 # 监听按键事件
-dbus-monitor --session "interface='org.deepin.dde.KeyEvent1'"
+dbus-monitor --system "interface='org.deepin.dde.KeyEvent1'"
 ```
 
 #### 问题 5：`modifiable=true` 但用户改键不持久化

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.ini
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.ini
@@ -14,6 +14,8 @@ org.deepin.dde.keybinding.shortcut.defaultterminal,\
 org.deepin.dde.keybinding.shortcut.displayswitch,\
 org.deepin.dde.keybinding.shortcut.documents,\
 org.deepin.dde.keybinding.shortcut.eject,\
+org.deepin.dde.keybinding.shortcut.hardware.cyclewindows,\
+org.deepin.dde.keybinding.shortcut.hardware.display,\
 org.deepin.dde.keybinding.shortcut.homepage,\
 org.deepin.dde.keybinding.shortcut.kbdlightdown,\
 org.deepin.dde.keybinding.shortcut.kbdlighttoggle,\

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.hardware.cyclewindows/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.hardware.cyclewindows/org.deepin.shortcut.json
@@ -13,55 +13,62 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Mic mute",
+            "value": "Cycle windows hardware key",
             "serial": 0,
             "flags": [],
             "name": "displayName",
-            "name[zh_CN]": "麦克风静音",
-            "description": "麦克风静音快捷键",
+            "name[zh_CN]": "多任务视图硬件键",
+            "description": "Legacy KEY_CYCLEWINDOWS compatibility binding",
             "permissions": "",
             "visibility": "private"
         },
         "hotkeys": {
             "value": [
-                "Microphone Mute",
-                "248"
+                "154"
             ],
-            "serial": 1,
+            "serial": 0,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",
-            "description": "XF86AudioMicMute and KEY_MICMUTE compatibility bindings",
+            "description": "KEY_CYCLEWINDOWS (linux/input-event-codes.h)",
             "permissions": "",
             "visibility": "private"
         },
         "triggerType": {
-            "value": 1,
+            "value": 3,
             "serial": 0,
             "flags": [],
             "name": "triggerType",
             "name[zh_CN]": "快捷键触发动作类型",
-            "description": "二进制command类型",
+            "description": "compositor action type",
             "permissions": "",
             "visibility": "private"
         },
         "triggerValue": {
             "value": [
-                "/usr/bin/dde-shortcut-tool",
-                "audio",
-                "mic-mute-toggle"
+                "18"
             ],
             "serial": 0,
             "flags": [],
             "name": "triggerValue",
             "name[zh_CN]": "快捷键触发动作",
-            "description": "触发动作",
+            "description": "18=toggle multitask view",
+            "permissions": "",
+            "visibility": "private"
+        },
+        "keyEventFlags": {
+            "value": 1,
+            "serial": 1,
+            "flags": [],
+            "name": "keyEventFlags",
+            "name[zh_CN]": "按键事件标志",
+            "description": "trigger on key press",
             "permissions": "",
             "visibility": "private"
         },
         "category": {
             "value": "System",
-            "serial": 1,
+            "serial": 0,
             "flags": [],
             "name": "category",
             "name[zh_CN]": "快捷键类别（System）",
@@ -85,7 +92,7 @@
             "flags": [],
             "name": "modifiable",
             "name[zh_CN]": "能否修改快捷键",
-            "description": "不能修改快捷键",
+            "description": "fixed hardware compatibility binding",
             "permissions": "",
             "visibility": "private"
         }

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.hardware.display/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.hardware.display/org.deepin.shortcut.json
@@ -13,25 +13,24 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Mic mute",
+            "value": "Display switch hardware key",
             "serial": 0,
             "flags": [],
             "name": "displayName",
-            "name[zh_CN]": "麦克风静音",
-            "description": "麦克风静音快捷键",
+            "name[zh_CN]": "显示切换硬件键",
+            "description": "Legacy XF86Display compatibility binding",
             "permissions": "",
             "visibility": "private"
         },
         "hotkeys": {
             "value": [
-                "Microphone Mute",
-                "248"
+                "Display"
             ],
-            "serial": 1,
+            "serial": 0,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",
-            "description": "XF86AudioMicMute and KEY_MICMUTE compatibility bindings",
+            "description": "XF86Display output switch key",
             "permissions": "",
             "visibility": "private"
         },
@@ -41,27 +40,37 @@
             "flags": [],
             "name": "triggerType",
             "name[zh_CN]": "快捷键触发动作类型",
-            "description": "二进制command类型",
+            "description": "command type",
             "permissions": "",
             "visibility": "private"
         },
         "triggerValue": {
             "value": [
                 "/usr/bin/dde-shortcut-tool",
-                "audio",
-                "mic-mute-toggle"
+                "display",
+                "switch-mode"
             ],
             "serial": 0,
             "flags": [],
             "name": "triggerValue",
             "name[zh_CN]": "快捷键触发动作",
-            "description": "触发动作",
+            "description": "switch multiple-display mode",
+            "permissions": "",
+            "visibility": "private"
+        },
+        "keyEventFlags": {
+            "value": 2,
+            "serial": 0,
+            "flags": [],
+            "name": "keyEventFlags",
+            "name[zh_CN]": "按键事件标志",
+            "description": "trigger on key release",
             "permissions": "",
             "visibility": "private"
         },
         "category": {
             "value": "System",
-            "serial": 1,
+            "serial": 0,
             "flags": [],
             "name": "category",
             "name[zh_CN]": "快捷键类别（System）",
@@ -85,7 +94,7 @@
             "flags": [],
             "name": "modifiable",
             "name[zh_CN]": "能否修改快捷键",
-            "description": "不能修改快捷键",
+            "description": "fixed hardware compatibility binding",
             "permissions": "",
             "visibility": "private"
         }

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.tools/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.tools/org.deepin.shortcut.json
@@ -24,15 +24,16 @@
         },
         "hotkeys": {
             "value": [
-                "Tools"
+                "Tools",
+                "141"
             ],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "hotkeys",
             "permissions": "",
             "visibility": "private",
             "name[zh_CN]": "快捷键组合",
-            "description": "快捷键组合"
+            "description": "XF86Tools and KEY_SETUP compatibility bindings"
         },
         "triggerType": {
             "value": 2,

--- a/src/plugin-qt/shortcut/src/backend/specialkeyhandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/specialkeyhandler.cpp
@@ -10,32 +10,42 @@
 #include <QDBusConnection>
 #include <QDBusServiceWatcher>
 
+namespace {
+
+constexpr auto KeyEventService = "org.deepin.dde.KeyEvent1";
+constexpr auto KeyEventPath = "/org/deepin/dde/KeyEvent1";
+constexpr auto KeyEventInterface = "org.deepin.dde.KeyEvent1";
+
+}
+
 SpecialKeyHandler::SpecialKeyHandler(QObject *parent)
     : QObject(parent)
     , m_connected(false)
 {
     // Connect to org.deepin.dde.KeyEvent1 signal
     m_connected = QDBusConnection::systemBus().connect(
-        "org.deepin.dde.KeyEvent1",           // service
-        "/org/deepin/dde/KeyEvent1",          // path
-        "org.deepin.dde.KeyEvent1",           // interface
-        "KeyEvent",                            // signal name
-        this,                                  // receiver
+        KeyEventService,    // service
+        KeyEventPath,       // path
+        KeyEventInterface,  // interface
+        "KeyEvent",         // signal name
+        this,               // receiver
         SLOT(onKeyEvent(uint,bool,bool,bool,bool,bool))
     );
 
     if (m_connected) {
-        qCInfo(logShortcut) << "SpecialKeyHandler: Connected to org.deepin.dde.KeyEvent1";
+        qCInfo(logShortcut) << "SpecialKeyHandler: Subscribed to org.deepin.dde.KeyEvent1";
     } else {
         qCWarning(logShortcut) << "SpecialKeyHandler: Failed to connect to org.deepin.dde.KeyEvent1";
     }
 
-    auto *serviceWatcher = new QDBusServiceWatcher(QStringLiteral("org.deepin.dde.KeyEvent1"),
+    auto *serviceWatcher = new QDBusServiceWatcher(QLatin1String(KeyEventService),
                                                    QDBusConnection::systemBus(),
                                                    QDBusServiceWatcher::WatchForUnregistration,
                                                    this);
     connect(serviceWatcher, &QDBusServiceWatcher::serviceUnregistered,
             this, [this]() {
+                qCCritical(logShortcut) << "SpecialKeyHandler: org.deepin.dde.KeyEvent1 stopped;"
+                                        << "raw hardware shortcuts are unavailable.";
                 m_keysHeld.clear();
                 m_suppressedKeys.clear();
             });
@@ -45,9 +55,9 @@ SpecialKeyHandler::~SpecialKeyHandler()
 {
     if (m_connected) {
         QDBusConnection::systemBus().disconnect(
-            "org.deepin.dde.KeyEvent1",
-            "/org/deepin/dde/KeyEvent1",
-            "org.deepin.dde.KeyEvent1",
+            KeyEventService,
+            KeyEventPath,
+            KeyEventInterface,
             "KeyEvent",
             this,
             SLOT(onKeyEvent(uint,bool,bool,bool,bool,bool))
@@ -61,6 +71,9 @@ bool SpecialKeyHandler::registerKey(const KeyConfig &config)
         qCWarning(logShortcut) << "SpecialKeyHandler: Not connected to KeyEvent1 service";
         return false;
     }
+
+    // Keep local registrations even when KeyEvent1 has no current owner. The
+    // D-Bus signal subscription survives service startup and restarts.
 
     if (m_shortcutKeycodes.contains(config.getId()))
         unregisterKey(config.getId());
@@ -137,14 +150,33 @@ void SpecialKeyHandler::clear()
 
 void SpecialKeyHandler::setEnabled(bool enabled)
 {
-    if (m_enabled == enabled)
+    if (m_inputEnabled == enabled)
+        return;
+
+    m_inputEnabled = enabled;
+    updateDispatchEnabled();
+}
+
+void SpecialKeyHandler::setSessionActive(bool active)
+{
+    if (m_sessionActive == active)
+        return;
+
+    m_sessionActive = active;
+    updateDispatchEnabled();
+}
+
+void SpecialKeyHandler::updateDispatchEnabled()
+{
+    const bool enabled = m_inputEnabled && m_sessionActive;
+    if (m_dispatchEnabled == enabled)
         return;
 
     if (!enabled) {
         m_suppressedKeys.unite(m_keysHeld);
         m_keysHeld.clear();
     }
-    m_enabled = enabled;
+    m_dispatchEnabled = enabled;
 }
 
 QString SpecialKeyHandler::lookupConflict(uint32_t keycode) const
@@ -193,12 +225,7 @@ void SpecialKeyHandler::onKeyEvent(uint keycode, bool pressed,
                                     bool ctrlPressed, bool shiftPressed, 
                                     bool altPressed, bool superPressed)
 {
-    Q_UNUSED(ctrlPressed)
-    Q_UNUSED(shiftPressed)
-    Q_UNUSED(altPressed)
-    Q_UNUSED(superPressed)
-
-    if (!m_enabled) {
+    if (!m_dispatchEnabled) {
         if (pressed)
             m_suppressedKeys.insert(keycode);
         else
@@ -213,6 +240,18 @@ void SpecialKeyHandler::onKeyEvent(uint keycode, bool pressed,
     }
     
     if (!m_keycodeBindings.contains(keycode)) {
+        return;
+    }
+
+    // Numeric hotkeys represent bare Linux keycodes.  Once any modifier is
+    // observed, suppress the sequence through release so a modified shortcut
+    // cannot also trigger its bare raw alias.
+    if (ctrlPressed || shiftPressed || altPressed || superPressed) {
+        m_keysHeld.remove(keycode);
+        if (pressed)
+            m_suppressedKeys.insert(keycode);
+        qCDebug(logShortcut) << "SpecialKeyHandler: Ignoring modified raw key sequence:"
+                             << keycode;
         return;
     }
     

--- a/src/plugin-qt/shortcut/src/backend/specialkeyhandler.h
+++ b/src/plugin-qt/shortcut/src/backend/specialkeyhandler.h
@@ -40,6 +40,7 @@ public:
     bool unregisterKey(const QString &shortcutId);
     void clear();
     void setEnabled(bool enabled);
+    void setSessionActive(bool active);
 
     /**
      * @brief Check if a keycode is already registered
@@ -77,6 +78,8 @@ private slots:
                     bool shiftPressed, bool altPressed, bool superPressed);
 
 private:
+    void updateDispatchEnabled();
+
     struct KeyBinding {
         QString shortcutId;
         int keyEventFlags;  // KeyEventFlag bitfield
@@ -93,5 +96,7 @@ private:
     QSet<uint32_t> m_suppressedKeys;
 
     bool m_connected;
-    bool m_enabled = true;
+    bool m_inputEnabled = true;
+    bool m_sessionActive = false;
+    bool m_dispatchEnabled = false;
 };

--- a/src/plugin-qt/shortcut/src/backend/x11/x11gesturehandler.cpp
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11gesturehandler.cpp
@@ -17,10 +17,12 @@ constexpr int WindowMoveTimeoutMs = 5000;
 
 }
 
-X11GestureHandler::X11GestureHandler(X11GestureActionExecutor *executor, QObject *parent)
+X11GestureHandler::X11GestureHandler(X11GestureActionExecutor *executor,
+                                     SessionActiveMonitor *sessionMonitor,
+                                     QObject *parent)
     : AbstractGestureHandler(parent)
     , m_proxy(new SystemGestureProxy(this))
-    , m_guard(new SessionGestureGuard(this))
+    , m_guard(new SessionGestureGuard(sessionMonitor, this))
     , m_executor(executor)
     , m_windowMoveTimeout(new QTimer(this))
 {

--- a/src/plugin-qt/shortcut/src/backend/x11/x11gesturehandler.h
+++ b/src/plugin-qt/shortcut/src/backend/x11/x11gesturehandler.h
@@ -12,12 +12,15 @@ class SessionGestureGuard;
 class SystemGestureProxy;
 class QTimer;
 class X11GestureActionExecutor;
+class SessionActiveMonitor;
 
 class X11GestureHandler : public AbstractGestureHandler
 {
     Q_OBJECT
 public:
-    explicit X11GestureHandler(X11GestureActionExecutor *executor, QObject *parent = nullptr);
+    explicit X11GestureHandler(X11GestureActionExecutor *executor,
+                               SessionActiveMonitor *sessionMonitor,
+                               QObject *parent = nullptr);
     ~X11GestureHandler() override;
 
     bool registerGesture(const GestureConfig &config) override;

--- a/src/plugin-qt/shortcut/src/core/crosschannelactivationguard.cpp
+++ b/src/plugin-qt/shortcut/src/core/crosschannelactivationguard.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "crosschannelactivationguard.h"
+
+bool CrossChannelActivationGuard::shouldAccept(const QString &shortcutId,
+                                               Channel channel,
+                                               qint64 timestampMs)
+{
+    const auto previous = m_lastAcceptedActivations.constFind(shortcutId);
+    if (previous != m_lastAcceptedActivations.constEnd()
+            && previous->channel != channel
+            && timestampMs >= previous->timestampMs
+            && timestampMs - previous->timestampMs <= CorrelationWindowMs) {
+        return false;
+    }
+
+    m_lastAcceptedActivations.insert(shortcutId, {channel, timestampMs});
+    return true;
+}
+
+void CrossChannelActivationGuard::clear(const QString &shortcutId)
+{
+    m_lastAcceptedActivations.remove(shortcutId);
+}
+
+void CrossChannelActivationGuard::clear()
+{
+    m_lastAcceptedActivations.clear();
+}

--- a/src/plugin-qt/shortcut/src/core/crosschannelactivationguard.h
+++ b/src/plugin-qt/shortcut/src/core/crosschannelactivationguard.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QHash>
+#include <QString>
+
+class CrossChannelActivationGuard
+{
+public:
+    enum class Channel {
+        Symbolic,
+        Raw,
+    };
+
+    // The symbolic and raw backends do not expose a common event identifier.
+    // Correlate only opposite-channel activations; rapid repeats reported by
+    // one channel remain independent user actions.
+    static constexpr qint64 CorrelationWindowMs = 200;
+
+    bool shouldAccept(const QString &shortcutId, Channel channel, qint64 timestampMs);
+    void clear(const QString &shortcutId);
+    void clear();
+
+private:
+    struct Activation {
+        Channel channel;
+        qint64 timestampMs;
+    };
+
+    QHash<QString, Activation> m_lastAcceptedActivations;
+};

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.cpp
@@ -15,6 +15,8 @@
 #include "core/shortcutconfig.h"
 #include "qkeysequenceconverter.h"
 #include "physicalkeyalias.h"
+#include "sessionactivemonitor.h"
+#include "triggeractioncatalog.h"
 #include "backend/x11/x11gestureactionexecutor.h"
 #include "backend/x11/x11numlockstatecontroller.h"
 
@@ -35,6 +37,18 @@ DGUI_USE_NAMESPACE
 namespace {
 constexpr const char *kDefaultShortcutAppId = "org.deepin.dde.keybinding";
 constexpr const char *kNoHotkeyText = "None";
+
+bool isFixedCompatibilityAlias(const KeyConfig &config)
+{
+    if (config.modifiable)
+        return false;
+
+    static const QSet<QString> fixedCompatibilityAliases{
+        QStringLiteral("org.deepin.dde.keybinding.shortcut.micmute"),
+        QStringLiteral("org.deepin.dde.keybinding.shortcut.tools"),
+    };
+    return fixedCompatibilityAliases.contains(config.getId());
+}
 
 const QHash<QString, int> &reservedCategoryOrder()
 {
@@ -278,17 +292,20 @@ static bool areValidShortcutHotkeys(const QStringList &hotkeys)
 KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *executor,
                                      TranslationManager *translationManager,
                                      AbstractKeyHandler *keyHandler,
+                                     SessionActiveMonitor *sessionMonitor,
                                      X11GestureActionExecutor *x11ActionExecutor,
                                      QObject *parent)
     : QObject(parent)
     , m_loader(loader)
     , m_keyHandler(keyHandler)
     , m_specialKeyHandler(new SpecialKeyHandler(this))
+    , m_sessionMonitor(sessionMonitor)
     , m_executor(executor)
     , m_translationManager(translationManager)
     , m_x11ActionExecutor(x11ActionExecutor)
     , m_isWayland(DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform))
 {
+    m_activationClock.start();
     qRegisterMetaType<ShortcutInfo>("ShortcutInfo");
     qRegisterMetaType<QList<ShortcutInfo>>("QList<ShortcutInfo>");
     qRegisterMetaType<KeyConfig>("KeyConfig");
@@ -300,6 +317,12 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
     qRegisterMetaType<QList<CategoryInfo>>("QList<CategoryInfo>");
     qDBusRegisterMetaType<CategoryInfo>();
     qDBusRegisterMetaType<QList<CategoryInfo>>();
+
+    connect(m_sessionMonitor, &SessionActiveMonitor::activeChanged,
+            this, [this](bool active) {
+        m_specialKeyHandler->setSessionActive(active);
+    });
+    m_specialKeyHandler->setSessionActive(m_sessionMonitor->isActive());
 
     // Connect signals from key handler
     connect(m_keyHandler, &AbstractKeyHandler::keyActivated, this, &KeybindingManager::onKeyActivated);
@@ -324,7 +347,8 @@ KeybindingManager::KeybindingManager(ConfigLoader *loader, ActionExecutor *execu
     m_lastNumLockState = GetNumLockState();
     
     // Connect signals from special key handler
-    connect(m_specialKeyHandler, &SpecialKeyHandler::keyActivated, this, &KeybindingManager::onKeyActivated);
+    connect(m_specialKeyHandler, &SpecialKeyHandler::keyActivated,
+            this, &KeybindingManager::onSpecialKeyActivated);
     
     connect(m_loader, &ConfigLoader::keyConfigChanged, this, &KeybindingManager::onKeyConfigChanged);
     connect(m_loader, &ConfigLoader::keyConfigAdded,
@@ -380,6 +404,7 @@ void KeybindingManager::clearState()
 {
     qCWarning(logShortcut) << "KeybindingManager: Marking runtime bindings inactive due to protocol disconnection";
     m_specialKeyHandler->clear();
+    m_crossChannelActivationGuard.clear();
     m_activeShortcutIds.clear();
 }
 
@@ -1268,18 +1293,65 @@ void KeybindingManager::onConfigRemoved(const QString &id)
 
 void KeybindingManager::onKeyActivated(const QString &shortcutId)
 {
-    qCDebug(logShortcut) << "Key activated:" << shortcutId;
-    
-    if (m_keyConfigsMap.contains(shortcutId) && m_activeShortcutIds.contains(shortcutId)) {
-        const auto &config = m_keyConfigsMap[shortcutId];
-        if (!m_isWayland && config.triggerType == static_cast<int>(TriggerType::Action)
-                && m_x11ActionExecutor) {
-            m_x11ActionExecutor->execute(config);
-        } else {
-            m_executor->execute(config);
-        }
-        emit ShortcutActivated(shortcutId, config.triggerValue);
+    activateShortcut(shortcutId, ShortcutActivationSource::Backend);
+}
+
+void KeybindingManager::onSpecialKeyActivated(const QString &shortcutId)
+{
+    activateShortcut(shortcutId, ShortcutActivationSource::SpecialKey);
+}
+
+void KeybindingManager::activateShortcut(const QString &shortcutId,
+                                         ShortcutActivationSource source)
+{
+    qCDebug(logShortcut) << "Key activated:" << shortcutId
+                         << "source:" << static_cast<int>(source);
+
+    const auto configIt = m_keyConfigsMap.constFind(shortcutId);
+    if (configIt == m_keyConfigsMap.constEnd() || !m_activeShortcutIds.contains(shortcutId))
+        return;
+
+    const bool isRawToggleMultitask = source == ShortcutActivationSource::SpecialKey
+            && configIt->triggerType == static_cast<int>(TriggerType::Action)
+            && !configIt->triggerValue.isEmpty()
+            && TriggerActionCatalog::resolve(configIt->triggerValue.constFirst())
+                    == TriggerActionId::ToggleMultitask;
+    if (isRawToggleMultitask && m_sessionMonitor->isLocked()) {
+        qCInfo(logShortcut) << "Ignoring raw multitask shortcut while session is locked:"
+                            << shortcutId;
+        return;
     }
+
+    if (source == ShortcutActivationSource::SpecialKey && m_isWayland
+            && configIt->triggerType == static_cast<int>(TriggerType::Action)) {
+        // TODO(wayland): Raw Linux keycodes arrive through KeyEvent1 instead of
+        // Treeland's shortcut protocol, so the compositor has not executed the
+        // configured action. Add an explicit Treeland action bridge before
+        // enabling or reporting keycode-only compositor actions on Wayland.
+        qCWarning(logShortcut) << "Special key compositor action is not supported on Wayland:"
+                               << shortcutId << configIt->triggerValue;
+        return;
+    }
+
+    if (!m_isWayland && isFixedCompatibilityAlias(*configIt)) {
+        const auto channel = source == ShortcutActivationSource::Backend
+                ? CrossChannelActivationGuard::Channel::Symbolic
+                : CrossChannelActivationGuard::Channel::Raw;
+        if (!m_crossChannelActivationGuard.shouldAccept(shortcutId, channel,
+                                                        m_activationClock.elapsed())) {
+            qCInfo(logShortcut) << "Ignoring correlated cross-channel shortcut activation:"
+                                << shortcutId << "source:" << static_cast<int>(source);
+            return;
+        }
+    }
+
+    if (!m_isWayland && configIt->triggerType == static_cast<int>(TriggerType::Action)
+            && m_x11ActionExecutor) {
+        m_x11ActionExecutor->execute(*configIt);
+    } else {
+        m_executor->execute(*configIt);
+    }
+    emit ShortcutActivated(shortcutId, configIt->triggerValue);
 }
 
 void KeybindingManager::onCaptureKeyEvent(bool pressed, const QString &keystroke)
@@ -1348,11 +1420,10 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringL
     if (normalHotkeys.isEmpty() && keycodeHotkeys.isEmpty())
         return false;
 
-    bool normalRegistered = normalHotkeys.isEmpty();
-    bool specialRegistered = keycodeHotkeys.isEmpty();
+    const auto registerNormalHotkeys = [&]() {
+        if (normalHotkeys.isEmpty())
+            return false;
 
-    // Register normal hotkeys via AbstractKeyHandler (X11/Wayland)
-    if (!normalHotkeys.isEmpty()) {
         // Check for conflicts before registering
         for (const QString &hotkey : normalHotkeys) {
             const QString conflictId = lookupRuntimeConflict(hotkey, excludeIds);
@@ -1362,37 +1433,72 @@ bool KeybindingManager::registerShortcut(const KeyConfig &config, const QStringL
                             << "Config displayName:" << config.displayName
                             << "Config hotkeys:" << config.hotkeys
                             << "Conflicts with:" << conflictId
-                            << "- Skipping registration";
+                            << "- Skipping symbolic registration";
                 return false;
             }
         }
 
-        // Create a config with only normal hotkeys
         KeyConfig normalConfig = config;
         normalConfig.hotkeys = normalHotkeys;
-        
-        normalRegistered = m_keyHandler->registerKey(normalConfig);
-        if (!normalRegistered)
-            return false;
-    }
+        if (m_keyHandler->registerKey(normalConfig))
+            return true;
 
-    // Register keycode hotkeys via SpecialKeyHandler
-    if (!keycodeHotkeys.isEmpty()) {
+        qCWarning(logShortcut) << "Failed to register symbolic hotkeys:"
+                               << config.getId() << normalHotkeys;
+        // Wayland may retain successful bindings from a partially failed batch.
+        m_keyHandler->unregisterKey(config.getId());
+        return false;
+    };
+
+    const auto registerSpecialHotkeys = [&]() {
+        if (keycodeHotkeys.isEmpty())
+            return false;
+
         KeyConfig keycodeConfig = config;
         keycodeConfig.hotkeys = keycodeHotkeys;
-        
-        specialRegistered = m_specialKeyHandler->registerKey(keycodeConfig);
-        if (!specialRegistered) {
-            if (normalRegistered && !normalHotkeys.isEmpty())
-                m_keyHandler->unregisterKey(config.getId());
-            return false;
+        if (m_specialKeyHandler->registerKey(keycodeConfig))
+            return true;
+
+        qCWarning(logShortcut) << "Failed to register raw keycode aliases:"
+                               << config.getId() << keycodeHotkeys;
+        m_specialKeyHandler->unregisterKey(config.getId());
+        return false;
+    };
+
+    if (isFixedCompatibilityAlias(config)
+            && !normalHotkeys.isEmpty() && !keycodeHotkeys.isEmpty()) {
+        // X11 hardware may expose either an XF86 symbol, a Linux keycode, or
+        // both. Register both channels and correlate duplicate activations at
+        // dispatch. Wayland keeps raw events as a registration fallback.
+        const bool symbolicRegistered = registerNormalHotkeys();
+        const bool rawRegistered = (!m_isWayland || !symbolicRegistered)
+                && registerSpecialHotkeys();
+        const bool registered = symbolicRegistered || rawRegistered;
+        if (registered) {
+            qCInfo(logShortcut) << "Registered fixed compatibility shortcut:"
+                                << config.getId()
+                                << "symbolic:" << symbolicRegistered
+                                << "raw:" << rawRegistered;
+            m_activeShortcutIds.insert(config.getId());
         }
+        return registered;
     }
 
-    if (normalRegistered && specialRegistered) {
+    const bool normalRegistered = normalHotkeys.isEmpty() || registerNormalHotkeys();
+    const bool specialRegistered = keycodeHotkeys.isEmpty() || registerSpecialHotkeys();
+    const bool allRequestedChannelsRegistered =
+            normalRegistered && specialRegistered;
+    if (allRequestedChannelsRegistered) {
         m_activeShortcutIds.insert(config.getId());
         return true;
     }
+
+    // Editable and ordinary configurations are transactional: never report a
+    // complete hotkey list as active when only one requested channel works.
+    if (!normalHotkeys.isEmpty())
+        m_keyHandler->unregisterKey(config.getId());
+    if (!keycodeHotkeys.isEmpty())
+        m_specialKeyHandler->unregisterKey(config.getId());
     return false;
 }
 
@@ -1400,6 +1506,7 @@ void KeybindingManager::unregisterShortcut(const QString &id)
 {
     m_keyHandler->unregisterKey(id);
     m_specialKeyHandler->unregisterKey(id);
+    m_crossChannelActivationGuard.clear(id);
     m_activeShortcutIds.remove(id);
 }
 

--- a/src/plugin-qt/shortcut/src/core/keybindingmanager.h
+++ b/src/plugin-qt/shortcut/src/core/keybindingmanager.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "shortcutconfig.h"
+#include "crosschannelactivationguard.h"
 
+#include <QElapsedTimer>
 #include <QObject>
 #include <QVariant>
 #include <QDBusContext>
@@ -17,6 +19,7 @@
 class ConfigLoader;
 class ActionExecutor;
 class AbstractKeyHandler;
+class SessionActiveMonitor;
 class SpecialKeyHandler;
 class TranslationManager;
 class X11GestureActionExecutor;
@@ -57,6 +60,7 @@ public:
     explicit KeybindingManager(ConfigLoader *loader, ActionExecutor *executor, 
                                TranslationManager *translationManager, 
                                AbstractKeyHandler *keyHandler,
+                               SessionActiveMonitor *sessionMonitor,
                                X11GestureActionExecutor *x11ActionExecutor = nullptr,
                                QObject *parent = nullptr);
     ~KeybindingManager() override;
@@ -125,6 +129,7 @@ private slots:
     void onKeyConfigChanged(const KeyConfig &config);
     void onConfigRemoved(const QString &id);
     void onKeyActivated(const QString &shortcutId);
+    void onSpecialKeyActivated(const QString &shortcutId);
     void onCaptureKeyEvent(bool pressed, const QString &keystroke);
     void updateNumLockState(bool on);
     void updateCapsLockState(bool on);
@@ -133,6 +138,11 @@ private slots:
     ShortcutInfo toShortcutInfo(const KeyConfig &config);
 
 private:
+    enum class ShortcutActivationSource {
+        Backend,
+        SpecialKey,
+    };
+
     enum class RollbackResult {
         Success,
         RebuildRequired,
@@ -158,6 +168,7 @@ private:
     void updateCustomShortcutConfigFields(KeyConfig &config, const QString &displayName,
                                           const QStringList &commandArguments,
                                           const QString &normalizedHotkey) const;
+    void activateShortcut(const QString &shortcutId, ShortcutActivationSource source);
 
     struct CustomShortcutChange {
         bool hasOldTarget = false;
@@ -177,6 +188,7 @@ private:
     ConfigLoader *m_loader;
     AbstractKeyHandler *m_keyHandler;
     SpecialKeyHandler *m_specialKeyHandler;
+    SessionActiveMonitor *m_sessionMonitor;
     ActionExecutor *m_executor;
     TranslationManager *m_translationManager;
     X11GestureActionExecutor *m_x11ActionExecutor;
@@ -185,6 +197,8 @@ private:
     QMap<QString, KeyConfig> m_keyConfigsMap;
     QSet<QString> m_activeShortcutIds;
     QSet<QString> m_resetInProgressIds;
+    CrossChannelActivationGuard m_crossChannelActivationGuard;
+    QElapsedTimer m_activationClock;
     uint m_lastNumLockState = 0;
     uint m_lastCapsLockState = 0;
     bool m_isWayland = false;

--- a/src/plugin-qt/shortcut/src/core/qkeysequenceconverter.cpp
+++ b/src/plugin-qt/shortcut/src/core/qkeysequenceconverter.cpp
@@ -71,6 +71,7 @@ static const QMap<QString, QString>& getQtToXkbMap() {
         map.insert("Keyboard Light On/Off", "XF86KbdLightOnOff");
         map.insert("Keyboard Brightness Up", "XF86KbdBrightnessUp");
         map.insert("Keyboard Brightness Down", "XF86KbdBrightnessDown");
+        map.insert("Display", "XF86Display");
         map.insert("Eject", "XF86Eject");
         map.insert("Touchpad Toggle", "XF86TouchpadToggle");
         map.insert("Touchpad On", "XF86TouchpadOn");

--- a/src/plugin-qt/shortcut/src/core/sessionactivemonitor.cpp
+++ b/src/plugin-qt/shortcut/src/core/sessionactivemonitor.cpp
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "shortcutlogging.h"
+
+#include "sessionactivemonitor.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusObjectPath>
+#include <QDBusServiceWatcher>
+#include <QDBusVariant>
+#include <QVariant>
+
+#include <functional>
+#include <utility>
+
+namespace {
+
+constexpr auto PropertiesInterface = "org.freedesktop.DBus.Properties";
+constexpr auto SessionManagerService = "org.deepin.dde.SessionManager1";
+constexpr auto SessionManagerPath = "/org/deepin/dde/SessionManager1";
+constexpr auto SessionManagerInterface = "org.deepin.dde.SessionManager1";
+constexpr auto LoginService = "org.freedesktop.login1";
+constexpr auto LoginSessionInterface = "org.freedesktop.login1.Session";
+
+QVariant unwrapDbusValue(const QVariant &value)
+{
+    if (value.metaType() == QMetaType::fromType<QDBusVariant>())
+        return qvariant_cast<QDBusVariant>(value).variant();
+    return value;
+}
+
+QString objectPathString(const QVariant &value)
+{
+    const QVariant unwrapped = unwrapDbusValue(value);
+    if (unwrapped.canConvert<QDBusObjectPath>())
+        return qvariant_cast<QDBusObjectPath>(unwrapped).path();
+    return unwrapped.toString();
+}
+
+class LoginSessionSignalRelay : public QObject
+{
+    Q_OBJECT
+public:
+    using Callback = std::function<void(const QString &, quint64, const QString &,
+                                        const QVariantMap &, const QStringList &)>;
+
+    LoginSessionSignalRelay(QString path, quint64 generation, Callback callback, QObject *parent)
+        : QObject(parent)
+        , m_path(std::move(path))
+        , m_generation(generation)
+        , m_callback(std::move(callback))
+    {
+    }
+
+private slots:
+    void onPropertiesChanged(const QString &interface, const QVariantMap &changed,
+                             const QStringList &invalidated)
+    {
+        m_callback(m_path, m_generation, interface, changed, invalidated);
+    }
+
+private:
+    QString m_path;
+    quint64 m_generation = 0;
+    Callback m_callback;
+};
+
+}
+
+SessionActiveMonitor::SessionActiveMonitor(QObject *parent)
+    : QObject(parent)
+{
+    QDBusConnection::sessionBus().connect(QLatin1String(SessionManagerService),
+                                          QLatin1String(SessionManagerPath),
+                                          QLatin1String(PropertiesInterface),
+                                          QStringLiteral("PropertiesChanged"),
+                                          this,
+                                          SLOT(onSessionManagerPropertiesChanged(QString,QVariantMap,QStringList)));
+
+    auto *sessionManagerWatcher = new QDBusServiceWatcher(
+            QLatin1String(SessionManagerService), QDBusConnection::sessionBus(),
+            QDBusServiceWatcher::WatchForRegistration
+                | QDBusServiceWatcher::WatchForUnregistration, this);
+    connect(sessionManagerWatcher, &QDBusServiceWatcher::serviceRegistered,
+            this, [this]() { refreshSessionManagerState(); });
+    connect(sessionManagerWatcher, &QDBusServiceWatcher::serviceUnregistered,
+            this, [this]() {
+        setLocked(true);
+        updateCurrentSession(QString());
+    });
+
+    auto *loginWatcher = new QDBusServiceWatcher(
+            QLatin1String(LoginService), QDBusConnection::systemBus(),
+            QDBusServiceWatcher::WatchForRegistration
+                | QDBusServiceWatcher::WatchForUnregistration, this);
+    connect(loginWatcher, &QDBusServiceWatcher::serviceRegistered,
+            this, [this]() { refreshLoginSessionState(); });
+    connect(loginWatcher, &QDBusServiceWatcher::serviceUnregistered,
+            this, [this]() { setActive(false); });
+
+    refreshSessionManagerState();
+}
+
+SessionActiveMonitor::~SessionActiveMonitor()
+{
+    disconnectLoginSessionSignal();
+}
+
+bool SessionActiveMonitor::isActive() const
+{
+    return m_active;
+}
+
+bool SessionActiveMonitor::isLocked() const
+{
+    return m_locked;
+}
+
+void SessionActiveMonitor::refreshSessionManagerState()
+{
+    QDBusInterface sessionManager(QLatin1String(SessionManagerService),
+                                  QLatin1String(SessionManagerPath),
+                                  QLatin1String(SessionManagerInterface),
+                                  QDBusConnection::sessionBus());
+    if (!sessionManager.isValid()) {
+        setLocked(true);
+        updateCurrentSession(QString());
+        return;
+    }
+
+    setLocked(sessionManager.property("Locked").toBool());
+    updateCurrentSession(objectPathString(sessionManager.property("CurrentSessionPath")));
+}
+
+void SessionActiveMonitor::refreshLoginSessionState()
+{
+    if (m_currentSessionPath.isEmpty()) {
+        setActive(false);
+        return;
+    }
+
+    QDBusInterface loginSession(QLatin1String(LoginService), m_currentSessionPath,
+                                QLatin1String(LoginSessionInterface),
+                                QDBusConnection::systemBus());
+    setActive(loginSession.isValid() && loginSession.property("Active").toBool());
+}
+
+void SessionActiveMonitor::updateCurrentSession(const QString &path)
+{
+    if (path == m_currentSessionPath && !path.isEmpty()) {
+        refreshLoginSessionState();
+        return;
+    }
+
+    disconnectLoginSessionSignal();
+    delete m_loginSessionSignalRelay;
+    m_loginSessionSignalRelay = nullptr;
+
+    m_currentSessionPath = path;
+    ++m_sessionGeneration;
+    setActive(false);
+    if (path.isEmpty())
+        return;
+
+    const quint64 generation = m_sessionGeneration;
+    m_loginSessionSignalRelay = new LoginSessionSignalRelay(
+            path, generation,
+            [this](const QString &signalPath, quint64 signalGeneration,
+                   const QString &interface, const QVariantMap &changed,
+                   const QStringList &invalidated) {
+        handleLoginSessionPropertiesChanged(signalPath, signalGeneration,
+                                            interface, changed, invalidated);
+    }, this);
+    QDBusConnection::systemBus().connect(QLatin1String(LoginService),
+                                         path,
+                                         QLatin1String(PropertiesInterface),
+                                         QStringLiteral("PropertiesChanged"),
+                                         m_loginSessionSignalRelay,
+                                         SLOT(onPropertiesChanged(QString,QVariantMap,QStringList)));
+    refreshLoginSessionState();
+}
+
+void SessionActiveMonitor::onSessionManagerPropertiesChanged(const QString &interface,
+                                                              const QVariantMap &changed,
+                                                              const QStringList &invalidated)
+{
+    if (interface != QLatin1String(SessionManagerInterface))
+        return;
+    if (changed.contains(QStringLiteral("Locked")))
+        setLocked(unwrapDbusValue(changed.value(QStringLiteral("Locked"))).toBool());
+    if (changed.contains(QStringLiteral("CurrentSessionPath")))
+        updateCurrentSession(objectPathString(changed.value(QStringLiteral("CurrentSessionPath"))));
+    if (invalidated.contains(QStringLiteral("Locked"))
+            || invalidated.contains(QStringLiteral("CurrentSessionPath"))) {
+        refreshSessionManagerState();
+    }
+}
+
+void SessionActiveMonitor::handleLoginSessionPropertiesChanged(const QString &path,
+                                                                quint64 generation,
+                                                                const QString &interface,
+                                                                const QVariantMap &changed,
+                                                                const QStringList &invalidated)
+{
+    if (path != m_currentSessionPath || generation != m_sessionGeneration
+            || interface != QLatin1String(LoginSessionInterface)) {
+        return;
+    }
+    if (changed.contains(QStringLiteral("Active")))
+        setActive(unwrapDbusValue(changed.value(QStringLiteral("Active"))).toBool());
+    if (invalidated.contains(QStringLiteral("Active")))
+        refreshLoginSessionState();
+}
+
+void SessionActiveMonitor::setActive(bool active)
+{
+    if (m_active == active)
+        return;
+
+    m_active = active;
+    qCInfo(logShortcut) << "Special key session active state changed:" << active;
+    emit activeChanged(active);
+}
+
+void SessionActiveMonitor::setLocked(bool locked)
+{
+    if (m_locked == locked)
+        return;
+
+    m_locked = locked;
+    qCInfo(logShortcut) << "Shortcut session locked state changed:" << locked;
+}
+
+void SessionActiveMonitor::disconnectLoginSessionSignal()
+{
+    if (m_currentSessionPath.isEmpty() || !m_loginSessionSignalRelay)
+        return;
+
+    QDBusConnection::systemBus().disconnect(QLatin1String(LoginService),
+                                            m_currentSessionPath,
+                                            QLatin1String(PropertiesInterface),
+                                            QStringLiteral("PropertiesChanged"),
+                                            m_loginSessionSignalRelay,
+                                            SLOT(onPropertiesChanged(QString,QVariantMap,QStringList)));
+}
+
+#include "sessionactivemonitor.moc"

--- a/src/plugin-qt/shortcut/src/core/sessionactivemonitor.h
+++ b/src/plugin-qt/shortcut/src/core/sessionactivemonitor.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QVariantMap>
+
+class SessionActiveMonitor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SessionActiveMonitor(QObject *parent = nullptr);
+    ~SessionActiveMonitor() override;
+
+    bool isActive() const;
+    bool isLocked() const;
+
+signals:
+    void activeChanged(bool active);
+
+private slots:
+    void onSessionManagerPropertiesChanged(const QString &interface,
+                                           const QVariantMap &changed,
+                                           const QStringList &invalidated);
+
+private:
+    void refreshSessionManagerState();
+    void refreshLoginSessionState();
+    void updateCurrentSession(const QString &path);
+    void handleLoginSessionPropertiesChanged(const QString &path, quint64 generation,
+                                             const QString &interface,
+                                             const QVariantMap &changed,
+                                             const QStringList &invalidated);
+    void setActive(bool active);
+    void setLocked(bool locked);
+    void disconnectLoginSessionSignal();
+
+    QString m_currentSessionPath;
+    quint64 m_sessionGeneration = 0;
+    bool m_active = false;
+    bool m_locked = true;
+    QObject *m_loginSessionSignalRelay = nullptr;
+};

--- a/src/plugin-qt/shortcut/src/core/sessiongestureguard.cpp
+++ b/src/plugin-qt/shortcut/src/core/sessiongestureguard.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "sessiongestureguard.h"
+#include "sessionactivemonitor.h"
 
 #include <QDBusConnection>
 #include <QDBusConnectionInterface>
 #include <QDBusInterface>
 #include <QDBusMessage>
-#include <QDBusObjectPath>
 #include <QDBusPendingCallWatcher>
 #include <QDBusPendingReply>
 #include <QDBusServiceWatcher>
@@ -19,17 +19,9 @@
 
 #include <xcb/xcb.h>
 
-#include <functional>
-#include <utility>
-
 namespace {
 
 constexpr auto PropertiesInterface = "org.freedesktop.DBus.Properties";
-constexpr auto SessionManagerService = "org.deepin.dde.SessionManager1";
-constexpr auto SessionManagerPath = "/org/deepin/dde/SessionManager1";
-constexpr auto SessionManagerInterface = "org.deepin.dde.SessionManager1";
-constexpr auto LoginService = "org.freedesktop.login1";
-constexpr auto LoginSessionInterface = "org.freedesktop.login1.Session";
 constexpr auto TouchpadService = "org.deepin.dde.InputDevices1";
 constexpr auto TouchpadPath = "/org/deepin/dde/InputDevice1/TouchPad";
 constexpr auto TouchpadInterface = "org.deepin.dde.InputDevice1.TouchPad";
@@ -44,46 +36,12 @@ QVariant unwrapDbusValue(const QVariant &value)
     return value;
 }
 
-class LoginSessionSignalRelay : public QObject
-{
-    Q_OBJECT
-public:
-    using Callback = std::function<void(const QString &, quint64, const QString &,
-                                        const QVariantMap &, const QStringList &)>;
-
-    LoginSessionSignalRelay(QString path, quint64 generation, Callback callback, QObject *parent)
-        : QObject(parent)
-        , m_path(std::move(path))
-        , m_generation(generation)
-        , m_callback(std::move(callback))
-    {
-    }
-
-private slots:
-    void onPropertiesChanged(const QString &interface, const QVariantMap &changed,
-                             const QStringList &invalidated)
-    {
-        m_callback(m_path, m_generation, interface, changed, invalidated);
-    }
-
-private:
-    QString m_path;
-    quint64 m_generation = 0;
-    Callback m_callback;
-};
-
-QString objectPathString(const QVariant &value)
-{
-    const QVariant unwrapped = unwrapDbusValue(value);
-    if (unwrapped.canConvert<QDBusObjectPath>())
-        return qvariant_cast<QDBusObjectPath>(unwrapped).path();
-    return unwrapped.toString();
 }
 
-}
-
-SessionGestureGuard::SessionGestureGuard(QObject *parent)
+SessionGestureGuard::SessionGestureGuard(SessionActiveMonitor *sessionMonitor,
+                                         QObject *parent)
     : QObject(parent)
+    , m_sessionMonitor(sessionMonitor)
     , m_multitaskRefreshTimer(new QTimer(this))
 {
     m_xConnection = xcb_connect(nullptr, nullptr);
@@ -93,30 +51,12 @@ SessionGestureGuard::SessionGestureGuard(QObject *parent)
             m_rootWindow = screen->root;
     }
 
-    QDBusConnection::sessionBus().connect(QLatin1String(SessionManagerService),
-                                          QLatin1String(SessionManagerPath),
-                                          QLatin1String(PropertiesInterface),
-                                          QStringLiteral("PropertiesChanged"),
-                                          this,
-                                          SLOT(onSessionManagerPropertiesChanged(QString,QVariantMap,QStringList)));
     QDBusConnection::sessionBus().connect(QLatin1String(TouchpadService),
                                           QLatin1String(TouchpadPath),
                                           QLatin1String(PropertiesInterface),
                                           QStringLiteral("PropertiesChanged"),
                                           this,
                                           SLOT(onTouchpadPropertiesChanged(QString,QVariantMap,QStringList)));
-
-    auto *sessionManagerWatcher = new QDBusServiceWatcher(
-            QLatin1String(SessionManagerService), QDBusConnection::sessionBus(),
-            QDBusServiceWatcher::WatchForRegistration
-                | QDBusServiceWatcher::WatchForUnregistration, this);
-    connect(sessionManagerWatcher, &QDBusServiceWatcher::serviceRegistered,
-            this, [this]() { refreshSessionManagerState(); });
-    connect(sessionManagerWatcher, &QDBusServiceWatcher::serviceUnregistered,
-            this, [this]() {
-        m_locked = true;
-        updateCurrentSession(QString());
-    });
 
     auto *touchpadWatcher = new QDBusServiceWatcher(
             QLatin1String(TouchpadService), QDBusConnection::sessionBus(),
@@ -127,15 +67,6 @@ SessionGestureGuard::SessionGestureGuard(QObject *parent)
     connect(touchpadWatcher, &QDBusServiceWatcher::serviceUnregistered,
             this, [this]() { m_touchpadEnabled = false; });
 
-    auto *loginWatcher = new QDBusServiceWatcher(
-            QLatin1String(LoginService), QDBusConnection::systemBus(),
-            QDBusServiceWatcher::WatchForRegistration
-                | QDBusServiceWatcher::WatchForUnregistration, this);
-    connect(loginWatcher, &QDBusServiceWatcher::serviceRegistered,
-            this, [this]() { refreshLoginSessionState(); });
-    connect(loginWatcher, &QDBusServiceWatcher::serviceUnregistered,
-            this, [this]() { m_sessionActive = false; });
-
     auto *wmWatcher = new QDBusServiceWatcher(
             QLatin1String(WmService), QDBusConnection::sessionBus(),
             QDBusServiceWatcher::WatchForRegistration
@@ -145,7 +76,6 @@ SessionGestureGuard::SessionGestureGuard(QObject *parent)
     connect(wmWatcher, &QDBusServiceWatcher::serviceUnregistered,
             this, [this]() { setWmOwner(QString()); });
 
-    refreshSessionManagerState();
     refreshTouchpadState();
     refreshWmOwner();
 
@@ -177,28 +107,13 @@ bool SessionGestureGuard::canHandleTouchpadGesture(const QString &gestureName) c
 
 bool SessionGestureGuard::canHandleTouchpadEvent() const
 {
-    return !m_locked && m_sessionActive && m_touchpadEnabled;
+    return m_sessionMonitor && !m_sessionMonitor->isLocked()
+            && m_sessionMonitor->isActive() && m_touchpadEnabled;
 }
 
 bool SessionGestureGuard::canBeginWindowMove() const
 {
     return canHandleTouchpadEvent() && !isKeyboardGrabbed();
-}
-
-void SessionGestureGuard::refreshSessionManagerState()
-{
-    QDBusInterface sessionManager(QLatin1String(SessionManagerService),
-                                  QLatin1String(SessionManagerPath),
-                                  QLatin1String(SessionManagerInterface),
-                                  QDBusConnection::sessionBus());
-    if (!sessionManager.isValid()) {
-        m_locked = true;
-        updateCurrentSession(QString());
-        return;
-    }
-
-    m_locked = sessionManager.property("Locked").toBool();
-    updateCurrentSession(objectPathString(sessionManager.property("CurrentSessionPath")));
 }
 
 void SessionGestureGuard::refreshTouchpadState()
@@ -208,93 +123,6 @@ void SessionGestureGuard::refreshTouchpadState()
                             QLatin1String(TouchpadInterface),
                             QDBusConnection::sessionBus());
     m_touchpadEnabled = touchpad.isValid() && touchpad.property("TPadEnable").toBool();
-}
-
-void SessionGestureGuard::updateCurrentSession(const QString &path)
-{
-    if (path == m_currentSessionPath && !path.isEmpty()) {
-        refreshLoginSessionState();
-        return;
-    }
-
-    if (!m_currentSessionPath.isEmpty() && m_loginSessionSignalRelay) {
-        QDBusConnection::systemBus().disconnect(QLatin1String(LoginService),
-                                                m_currentSessionPath,
-                                                QLatin1String(PropertiesInterface),
-                                                QStringLiteral("PropertiesChanged"),
-                                                m_loginSessionSignalRelay,
-                                                SLOT(onPropertiesChanged(QString,QVariantMap,QStringList)));
-    }
-    delete m_loginSessionSignalRelay;
-    m_loginSessionSignalRelay = nullptr;
-
-    m_currentSessionPath = path;
-    ++m_sessionGeneration;
-    m_sessionActive = false;
-    if (path.isEmpty())
-        return;
-
-    const quint64 generation = m_sessionGeneration;
-    m_loginSessionSignalRelay = new LoginSessionSignalRelay(
-            path, generation,
-            [this](const QString &signalPath, quint64 signalGeneration,
-                   const QString &interface, const QVariantMap &changed,
-                   const QStringList &invalidated) {
-        handleLoginSessionPropertiesChanged(signalPath, signalGeneration,
-                                            interface, changed, invalidated);
-    }, this);
-    QDBusConnection::systemBus().connect(QLatin1String(LoginService),
-                                         path,
-                                         QLatin1String(PropertiesInterface),
-                                         QStringLiteral("PropertiesChanged"),
-                                         m_loginSessionSignalRelay,
-                                         SLOT(onPropertiesChanged(QString,QVariantMap,QStringList)));
-    refreshLoginSessionState();
-}
-
-void SessionGestureGuard::refreshLoginSessionState()
-{
-    if (m_currentSessionPath.isEmpty()) {
-        m_sessionActive = false;
-        return;
-    }
-    QDBusInterface loginSession(QLatin1String(LoginService), m_currentSessionPath,
-                                QLatin1String(LoginSessionInterface),
-                                QDBusConnection::systemBus());
-    m_sessionActive = loginSession.isValid() && loginSession.property("Active").toBool();
-}
-
-void SessionGestureGuard::onSessionManagerPropertiesChanged(const QString &interface,
-                                                             const QVariantMap &changed,
-                                                             const QStringList &invalidated)
-{
-    if (interface != QLatin1String(SessionManagerInterface))
-        return;
-    if (changed.contains(QStringLiteral("Locked")))
-        m_locked = unwrapDbusValue(changed.value(QStringLiteral("Locked"))).toBool();
-    if (changed.contains(QStringLiteral("CurrentSessionPath")))
-        updateCurrentSession(objectPathString(changed.value(QStringLiteral("CurrentSessionPath"))));
-    if (invalidated.contains(QStringLiteral("Locked"))
-            || invalidated.contains(QStringLiteral("CurrentSessionPath"))) {
-        refreshSessionManagerState();
-    }
-}
-
-void SessionGestureGuard::handleLoginSessionPropertiesChanged(const QString &path,
-                                                               quint64 generation,
-                                                               const QString &interface,
-                                                               const QVariantMap &changed,
-                                                               const QStringList &invalidated)
-{
-    if (path != m_currentSessionPath || generation != m_sessionGeneration
-            || interface != QLatin1String(LoginSessionInterface)) {
-        return;
-    }
-    if (changed.contains(QStringLiteral("Active")))
-        m_sessionActive = unwrapDbusValue(changed.value(QStringLiteral("Active"))).toBool();
-    if (invalidated.contains(QStringLiteral("Active"))) {
-        refreshLoginSessionState();
-    }
 }
 
 void SessionGestureGuard::onTouchpadPropertiesChanged(const QString &interface,
@@ -392,5 +220,3 @@ bool SessionGestureGuard::isKeyboardGrabbed() const
     }
     return true;
 }
-
-#include "sessiongestureguard.moc"

--- a/src/plugin-qt/shortcut/src/core/sessiongestureguard.h
+++ b/src/plugin-qt/shortcut/src/core/sessiongestureguard.h
@@ -6,11 +6,11 @@
 
 #include <QObject>
 #include <QVariantMap>
-
 #include <cstdint>
 
 class QDBusPendingCallWatcher;
 class QTimer;
+class SessionActiveMonitor;
 typedef struct xcb_connection_t xcb_connection_t;
 typedef uint32_t xcb_window_t;
 
@@ -18,7 +18,8 @@ class SessionGestureGuard : public QObject
 {
     Q_OBJECT
 public:
-    explicit SessionGestureGuard(QObject *parent = nullptr);
+    explicit SessionGestureGuard(SessionActiveMonitor *sessionMonitor,
+                                 QObject *parent = nullptr);
     ~SessionGestureGuard() override;
 
     bool canHandleTouchpadEvent() const;
@@ -26,9 +27,6 @@ public:
     bool canBeginWindowMove() const;
 
 private slots:
-    void onSessionManagerPropertiesChanged(const QString &interface,
-                                           const QVariantMap &changed,
-                                           const QStringList &invalidated);
     void onTouchpadPropertiesChanged(const QString &interface,
                                      const QVariantMap &changed,
                                      const QStringList &invalidated);
@@ -36,28 +34,17 @@ private slots:
     void onMultitaskStateFinished(QDBusPendingCallWatcher *watcher);
 
 private:
-    void refreshSessionManagerState();
     void refreshTouchpadState();
-    void refreshLoginSessionState();
-    void updateCurrentSession(const QString &path);
-    void handleLoginSessionPropertiesChanged(const QString &path, quint64 generation,
-                                             const QString &interface,
-                                             const QVariantMap &changed,
-                                             const QStringList &invalidated);
     void refreshWmOwner();
     void setWmOwner(const QString &owner);
     bool isKeyboardGrabbed() const;
 
-    QString m_currentSessionPath;
-    quint64 m_sessionGeneration = 0;
-    bool m_locked = true;
-    bool m_sessionActive = false;
+    SessionActiveMonitor *m_sessionMonitor = nullptr;
     bool m_touchpadEnabled = false;
     bool m_multitaskVisible = false;
     QString m_wmOwner;
     quint64 m_wmGeneration = 0;
     quint64 m_multitaskPendingGeneration = 0;
-    QObject *m_loginSessionSignalRelay = nullptr;
     QTimer *m_multitaskRefreshTimer = nullptr;
     xcb_connection_t *m_xConnection = nullptr;
     xcb_window_t m_rootWindow = 0;

--- a/src/plugin-qt/shortcut/src/core/shortcutmanager.cpp
+++ b/src/plugin-qt/shortcut/src/core/shortcutmanager.cpp
@@ -10,6 +10,7 @@
 #include "actionexecutor.h"
 #include "serviceactionexecutor.h"
 #include "translationmanager.h"
+#include "sessionactivemonitor.h"
 #include "config/configloader.h"
 #include "backend/x11/x11keyhandler.h"
 #include "backend/x11/x11gesturehandler.h"
@@ -32,6 +33,7 @@ ShortcutManager::ShortcutManager(QObject *parent)
     , m_executor(new ActionExecutor(this))
     , m_translationManager(new TranslationManager(this))
     , m_serviceActionExecutor(new ServiceActionExecutor(m_executor, this))
+    , m_sessionMonitor(new SessionActiveMonitor(this))
 {
     m_isWayland = DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform);
 }
@@ -53,7 +55,8 @@ bool ShortcutManager::init()
     } else {
         m_keyHandler = new X11KeyHandler(this);
         m_x11GestureActionExecutor = new X11GestureActionExecutor(this);
-        m_gestureHandler = new X11GestureHandler(m_x11GestureActionExecutor, this);
+        m_gestureHandler = new X11GestureHandler(m_x11GestureActionExecutor,
+                                                 m_sessionMonitor, this);
     }
 
     if (!m_keyHandler || !m_keyHandler->isAvailable()) {
@@ -62,7 +65,8 @@ bool ShortcutManager::init()
     }
 
     m_keybindingManager = new KeybindingManager(m_loader, m_executor, m_translationManager,
-                                                m_keyHandler, m_x11GestureActionExecutor, this);
+                                                m_keyHandler, m_sessionMonitor,
+                                                m_x11GestureActionExecutor, this);
 
     m_gestureManager = new GestureManager(m_loader, m_executor, m_translationManager, m_gestureHandler,
                                           m_x11GestureActionExecutor, m_serviceActionExecutor, this);

--- a/src/plugin-qt/shortcut/src/core/shortcutmanager.h
+++ b/src/plugin-qt/shortcut/src/core/shortcutmanager.h
@@ -16,6 +16,7 @@ class AbstractGestureHandler;
 class TreelandShortcutWrapper;
 class X11GestureActionExecutor;
 class ServiceActionExecutor;
+class SessionActiveMonitor;
 
 /**
  * @brief ShortcutManager - Shortcut service coordinator
@@ -63,6 +64,7 @@ private:
     TranslationManager *m_translationManager = nullptr;
     X11GestureActionExecutor *m_x11GestureActionExecutor = nullptr;
     ServiceActionExecutor *m_serviceActionExecutor = nullptr;
+    SessionActiveMonitor *m_sessionMonitor = nullptr;
 
     // Handler (created by ShortcutManager, passed to Manager)
     AbstractKeyHandler *m_keyHandler = nullptr;

--- a/src/plugin-qt/shortcut/tests/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/tests/CMakeLists.txt
@@ -90,6 +90,41 @@ target_link_libraries(tst-qkeysequenceconverter PRIVATE
 
 add_test(NAME shortcut-qkeysequenceconverter COMMAND tst-qkeysequenceconverter)
 
+add_executable(tst-specialkeyhandler
+    tst_specialkeyhandler.cpp
+    ../shortcutlogging.cpp
+    ../src/backend/specialkeyhandler.cpp
+)
+
+target_include_directories(tst-specialkeyhandler PRIVATE
+    ..
+    ../src
+)
+
+target_link_libraries(tst-specialkeyhandler PRIVATE
+    Qt6::Core
+    Qt6::DBus
+    Qt6::Test
+)
+
+add_test(NAME shortcut-specialkeyhandler COMMAND tst-specialkeyhandler)
+
+add_executable(tst-crosschannelactivationguard
+    tst_crosschannelactivationguard.cpp
+    ../src/core/crosschannelactivationguard.cpp
+)
+
+target_include_directories(tst-crosschannelactivationguard PRIVATE
+    ../src
+)
+
+target_link_libraries(tst-crosschannelactivationguard PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME shortcut-crosschannelactivationguard COMMAND tst-crosschannelactivationguard)
+
 add_executable(tst-modifierkeystate
     tst_modifierkeystate.cpp
     ../src/backend/x11/modifierkeystate.cpp

--- a/src/plugin-qt/shortcut/tests/tst_crosschannelactivationguard.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_crosschannelactivationguard.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "core/crosschannelactivationguard.h"
+
+#include <QtTest>
+
+class TestCrossChannelActivationGuard : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void suppressesOnlyCorrelatedOtherChannelActivation();
+    void acceptsSameChannelRapidActivations();
+    void suppressedActivationDoesNotReplaceAcceptedSource();
+    void acceptsOtherChannelOutsideCorrelationWindow();
+};
+
+void TestCrossChannelActivationGuard::suppressesOnlyCorrelatedOtherChannelActivation()
+{
+    CrossChannelActivationGuard guard;
+    const QString id = QStringLiteral("micmute");
+
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Symbolic, 1000));
+    QVERIFY(!guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Raw, 1010));
+}
+
+void TestCrossChannelActivationGuard::acceptsSameChannelRapidActivations()
+{
+    CrossChannelActivationGuard guard;
+    const QString id = QStringLiteral("micmute");
+
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Raw, 1000));
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Raw, 1010));
+}
+
+void TestCrossChannelActivationGuard::suppressedActivationDoesNotReplaceAcceptedSource()
+{
+    CrossChannelActivationGuard guard;
+    const QString id = QStringLiteral("micmute");
+
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Symbolic, 1000));
+    QVERIFY(!guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Raw, 1010));
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Symbolic, 1020));
+    QVERIFY(!guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Raw, 1030));
+}
+
+void TestCrossChannelActivationGuard::acceptsOtherChannelOutsideCorrelationWindow()
+{
+    CrossChannelActivationGuard guard;
+    const QString id = QStringLiteral("micmute");
+
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Symbolic, 1000));
+    QVERIFY(guard.shouldAccept(id, CrossChannelActivationGuard::Channel::Raw,
+                               1000 + CrossChannelActivationGuard::CorrelationWindowMs + 1));
+}
+
+QTEST_GUILESS_MAIN(TestCrossChannelActivationGuard)
+
+#include "tst_crosschannelactivationguard.moc"

--- a/src/plugin-qt/shortcut/tests/tst_qkeysequenceconverter.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_qkeysequenceconverter.cpp
@@ -26,6 +26,8 @@ void TestQKeySequenceConverter::symbolKeysUseXkbNames_data()
                                << QStringLiteral("<Super>minus");
     QTest::newRow("equal") << QStringLiteral("Meta+=")
                             << QStringLiteral("<Super>equal");
+    QTest::newRow("display") << QStringLiteral("Display")
+                              << QStringLiteral("XF86Display");
 }
 
 void TestQKeySequenceConverter::symbolKeysUseXkbNames()

--- a/src/plugin-qt/shortcut/tests/tst_specialkeyhandler.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_specialkeyhandler.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "backend/specialkeyhandler.h"
+
+#include <QDBusConnection>
+#include <QSignalSpy>
+#include <QtTest>
+
+class TestSpecialKeyHandler : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void registrationAndPressActivation();
+};
+
+void TestSpecialKeyHandler::registrationAndPressActivation()
+{
+    if (!QDBusConnection::systemBus().isConnected())
+        QSKIP("A system bus connection is required");
+
+    SpecialKeyHandler handler;
+    KeyConfig config;
+    config.subPath = QStringLiteral("hardware.cyclewindows");
+    config.hotkeys = {QStringLiteral("154")};
+    config.keyEventFlags = KeyEventFlag::Press;
+
+    QVERIFY(handler.registerKey(config));
+    QCOMPARE(handler.lookupConflict(154), config.getId());
+
+    QSignalSpy activationSpy(&handler, &SpecialKeyHandler::keyActivated);
+    handler.setSessionActive(true);
+    QVERIFY(QMetaObject::invokeMethod(&handler, "onKeyEvent", Qt::DirectConnection,
+                                      Q_ARG(uint, 154U), Q_ARG(bool, true),
+                                      Q_ARG(bool, false), Q_ARG(bool, false),
+                                      Q_ARG(bool, false), Q_ARG(bool, false)));
+    QCOMPARE(activationSpy.count(), 1);
+    QVERIFY(QMetaObject::invokeMethod(&handler, "onKeyEvent", Qt::DirectConnection,
+                                      Q_ARG(uint, 154U), Q_ARG(bool, false),
+                                      Q_ARG(bool, false), Q_ARG(bool, false),
+                                      Q_ARG(bool, false), Q_ARG(bool, false)));
+    QCOMPARE(activationSpy.count(), 1);
+    QCOMPARE(activationSpy.first().first().toString(), config.getId());
+}
+
+QTEST_GUILESS_MAIN(TestSpecialKeyHandler)
+
+#include "tst_specialkeyhandler.moc"


### PR DESCRIPTION
## Summary

- support legacy raw hardware keycodes alongside symbolic XF86 shortcuts
- register both X11 channels and suppress correlated duplicate activations within 200 ms
- share session-state checks and add focused shortcut backend and correlation tests

## Test plan

- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure` (10 passed; 2 X11 hardware suites skipped because no local X server is available)
- verified on X11 hardware that raw mic-mute keycode 248 triggers exactly once per press

Pms: BUG-373091

## Summary by Sourcery

Support legacy hardware shortcut keycodes alongside symbolic XF86 shortcuts and centralize session activity state for shortcut and gesture handling.

New Features:
- Add support for registering and activating raw hardware keycode aliases for selected shortcuts in parallel with their symbolic XF86 bindings on X11.
- Introduce a session activity monitor shared between keybinding and gesture subsystems to track locked/active session state.
- Add a cross-channel activation guard to suppress duplicate shortcut executions when both raw and symbolic bindings fire for the same action within a short window.

Enhancements:
- Gate raw hardware shortcut dispatch on session activity and lock state, and prevent modified key sequences from triggering bare keycode aliases.
- Adjust shortcut registration so symbolic and raw channels can succeed independently while maintaining transactional behavior for editable shortcuts.
- Route special-key activations through dedicated handling in the keybinding manager and improve logging around hardware shortcut availability and execution.
- Extend key sequence conversion to map the "Display" key to XF86Display and register new hardware display and window-cycle shortcuts in configuration.

Documentation:
- Update the developer guide to document monitoring hardware key events via the system bus KeyEvent1 interface instead of the session bus.

Tests:
- Add unit tests for the special key handler’s registration and activation behavior against KeyEvent1.
- Add unit tests for the cross-channel activation guard’s correlation logic between symbolic and raw channels.
- Update shortcut test CMake configuration to build and run the new focused tests for legacy hardware handling and activation correlation.