### PR TITLE
fix: update default shortcut settings

### DIFF
--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.cancel-maximize/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.cancel-maximize/org.deepin.shortcut.json
@@ -13,8 +13,8 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Cancel Maximize Window",
-            "serial": 0,
+            "value": "Restore window",
+            "serial": 1,
             "flags": [],
             "name": "displayName",
             "name[zh_CN]": "恢复窗口",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.move-left-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.move-left-workspace/org.deepin.shortcut.json
@@ -34,10 +34,10 @@
     },
     "hotkeys": {
       "value": [
-        "Ctrl+Shift+Alt+Left"
+        "Shift+Meta+Left"
       ],
       "permissions": "readwrite",
-      "serial": 0,
+      "serial": 1,
       "flags": [],
       "name": "hotkeys",
       "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.move-right-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.move-right-workspace/org.deepin.shortcut.json
@@ -34,10 +34,10 @@
     },
     "hotkeys": {
       "value": [
-        "Ctrl+Shift+Alt+Right"
+        "Shift+Meta+Right"
       ],
       "permissions": "readwrite",
-      "serial": 0,
+      "serial": 1,
       "flags": [],
       "name": "hotkeys",
       "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.next-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.next-workspace/org.deepin.shortcut.json
@@ -34,9 +34,9 @@
         },
         "hotkeys": {
             "value": [
-                "Ctrl+Alt+Right"
+                "Meta+Ctrl+Right"
             ],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.prev-workspace/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.prev-workspace/org.deepin.shortcut.json
@@ -34,9 +34,9 @@
         },
         "hotkeys": {
             "value": [
-                "Ctrl+Alt+Left"
+                "Meta+Ctrl+Left"
             ],
-            "serial": 0,
+            "serial": 1,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-next/org.deepin.shortcut.json
@@ -23,8 +23,8 @@
             "visibility": "private"
         },
         "displayOrder": {
-            "value": 150,
-            "serial": 1,
+            "value": 100,
+            "serial": 2,
             "flags": [],
             "name": "displayOrder",
             "name[zh_CN]": "显示顺序",
@@ -77,12 +77,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": "System",
-            "serial": 1,
+            "value": "Window",
+            "serial": 2,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别（System）",
-            "description": "System shortcut category",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-prev/org.deepin.shortcut.json
@@ -23,8 +23,8 @@
             "visibility": "private"
         },
         "displayOrder": {
-            "value": 160,
-            "serial": 1,
+            "value": 110,
+            "serial": 2,
             "flags": [],
             "name": "displayOrder",
             "name[zh_CN]": "显示顺序",
@@ -77,12 +77,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": "System",
-            "serial": 1,
+            "value": "Window",
+            "serial": 2,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别（System）",
-            "description": "System shortcut category",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-next/org.deepin.shortcut.json
@@ -23,8 +23,8 @@
             "visibility": "private"
         },
         "displayOrder": {
-            "value": 110,
-            "serial": 1,
+            "value": 120,
+            "serial": 2,
             "flags": [],
             "name": "displayOrder",
             "name[zh_CN]": "显示顺序",
@@ -77,12 +77,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": "System",
-            "serial": 1,
+            "value": "Window",
+            "serial": 2,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别（System）",
-            "description": "System shortcut category",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.taskswitch-sameapp-prev/org.deepin.shortcut.json
@@ -23,8 +23,8 @@
             "visibility": "private"
         },
         "displayOrder": {
-            "value": 120,
-            "serial": 1,
+            "value": 130,
+            "serial": 2,
             "flags": [],
             "name": "displayOrder",
             "name[zh_CN]": "显示顺序",
@@ -77,12 +77,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": "System",
-            "serial": 1,
+            "value": "Window",
+            "serial": 2,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别（System）",
-            "description": "System shortcut category",
+            "name[zh_CN]": "快捷键类别（Window）",
+            "description": "Window shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-multitaskview/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.toggle-multitaskview/org.deepin.shortcut.json
@@ -23,8 +23,8 @@
             "visibility": "private"
         },
         "displayOrder": {
-            "value": 130,
-            "serial": 1,
+            "value": 0,
+            "serial": 2,
             "flags": [],
             "name": "displayOrder",
             "name[zh_CN]": "显示顺序",
@@ -77,12 +77,12 @@
             "visibility": "private"
         },
         "category": {
-            "value": "System",
-            "serial": 1,
+            "value": "Workspace",
+            "serial": 2,
             "flags": [],
             "name": "category",
-            "name[zh_CN]": "快捷键类别（System）",
-            "description": "System shortcut category",
+            "name[zh_CN]": "快捷键类别（Workspace）",
+            "description": "Workspace shortcut category",
             "permissions": "",
             "visibility": "private"
         },

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.wm-switcher/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/configs/org.deepin.dde.keybinding.shortcut.app.wm-switcher/org.deepin.shortcut.json
@@ -23,8 +23,8 @@
       "visibility": "private"
     },
     "displayOrder": {
-      "value": 210,
-      "serial": 0,
+      "value": 140,
+      "serial": 1,
       "flags": [],
       "name": "displayOrder",
       "name[zh_CN]": "显示顺序",
@@ -79,8 +79,8 @@
       "visibility": "private"
     },
     "category": {
-      "value": "System",
-      "serial": 0,
+      "value": "Window",
+      "serial": 1,
       "flags": [],
       "name": "category",
       "name[zh_CN]": "快捷键类别",

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ast.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_az.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bg.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_bo.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>Cancel·la la maximització de la finestra</translation>
+        <translation type="vanished">Cancel·la la maximització de la finestra</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -43,7 +45,7 @@
     </message>
     <message>
         <source>Open window menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -63,7 +65,7 @@
     </message>
     <message>
         <source>Grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>OCR (Image to Text)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>Mida real</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_cs.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_da.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_de.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_el.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_en.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_es.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_et.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_eu.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fa.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>Peruuta suurennettu ikkuna</translation>
+        <translation type="vanished">Peruuta suurennettu ikkuna</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -43,7 +45,7 @@
     </message>
     <message>
         <source>Open window menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -63,7 +65,7 @@
     </message>
     <message>
         <source>Grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>OCR (Image to Text)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
@@ -95,87 +97,91 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_fr.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_gl.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_he.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hi.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hr.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hu.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_hy.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_id.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_it.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>ウィンドウの最大化を解除</translation>
+        <translation type="vanished">ウィンドウの最大化を解除</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -43,7 +45,7 @@
     </message>
     <message>
         <source>Open window menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -63,7 +65,7 @@
     </message>
     <message>
         <source>Grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -79,103 +81,107 @@
     </message>
     <message>
         <source>OCR (Image to Text)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ka.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_kk.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ko.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ky.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lt.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_lv.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ms.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nb.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ne.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_nl.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pa.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>Przywróć okno</translation>
+        <translation type="vanished">Przywróć okno</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>Przybliż do rozmiaru rzeczywistego</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>Cancelar Maximização da Janela</translation>
+        <translation type="vanished">Cancelar Maximização da Janela</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>Aumentar para o Tamanho Atual</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>Cancelar maximização da janela</translation>
+        <translation type="vanished">Cancelar maximização da janela</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>Exibir no tamanho real</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ro.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ru.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sk.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sl.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>Anulo Maksimizim Dritareje</translation>
+        <translation type="vanished">Anulo Maksimizim Dritareje</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -43,7 +45,7 @@
     </message>
     <message>
         <source>Open window menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle Multitask View</source>
@@ -63,7 +65,7 @@
     </message>
     <message>
         <source>Grand search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screenshot</source>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>OCR (Image to Text)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
@@ -95,87 +97,91 @@
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Minimize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Move to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen Recorder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scrollshot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Window Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch Windows of the Same Type Reversely</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Left Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Switch to Right Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Quick Tile Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom Out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Zoom to Actual Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sr.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_sv.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_th.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_tr.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_ug.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_uk.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_vi.ts
@@ -28,10 +28,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel Maximize Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Close Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,6 +173,10 @@
     </message>
     <message>
         <source>Zoom to Actual Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>取消最大化窗口</translation>
+        <translation type="vanished">取消最大化窗口</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>重置屏幕缩放</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_HK.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>取消最大化視窗</translation>
+        <translation type="vanished">取消最大化視窗</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>重設屏幕縮放</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
+++ b/src/plugin-qt/shortcut/dde-app-shortcuts/translations/org.deepin.dde.shortcut.dde-app_zh_TW.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>org.deepin.dde.shortcut.dde-app</name>
     <message>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Cancel Maximize Window</source>
-        <translation>取消最大化視窗</translation>
+        <translation type="vanished">取消最大化視窗</translation>
     </message>
     <message>
         <source>Close Window</source>
@@ -176,6 +178,10 @@
     <message>
         <source>Zoom to Actual Size</source>
         <translation>重設螢幕縮放</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

- update workspace navigation and window-move default shortcuts with DConfig serial increments
- regroup task switching and multitask-view shortcuts with the requested display order
- rename the restore-window source label and refresh all dde-app TS catalogs

## Translation note

- this PR updates translation sources only
- specific Chinese translations will be handled after this PR

## Test plan

- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure -R shortcut-(physicalkeyalias|triggeractioncatalog|qkeysequenceconverter|x11shortcutpolicy|x11wmaccelconverter)`
- validate all changed JSON and TS files

## Summary by Sourcery

Update default shortcut configurations and translation catalogs to reflect revised window management and workspace navigation actions.

New Features:
- Introduce a new "Restore window" shortcut action in the dde-app shortcut catalogs and configs.

Enhancements:
- Normalize Qt TS translation files to use UTF-8 XML headers and updated message metadata for window management actions.
- Regroup task switching and multitask view shortcut definitions to match the desired display order in the default configs.
- Adjust workspace navigation and window-move default shortcut configs to align with updated DConfig key sequences.

Chores:
- Mark the legacy "Cancel Maximize Window" shortcut strings as vanished across translations to deprecate the old action.