### PR TITLE
feat: migrate camera shortcut and helper scripts

### DIFF
--- a/src/plugin-qt/shortcut/CMakeLists.txt
+++ b/src/plugin-qt/shortcut/CMakeLists.txt
@@ -171,6 +171,11 @@ endforeach()
 install(FILES configs/org.deepin.dde.keybinding.ini 
         DESTINATION share/deepin/org.deepin.dde.keybinding)
 
+install(PROGRAMS
+        scripts/camera-switch
+        scripts/toggle-grand-search
+        DESTINATION libexec/dde-services/keybinding)
+
 # ============ i18n Translation Support ============
 # Install i18n extraction tool
 install(PROGRAMS tools/extract_shortcuts_i18n.py 

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.ini
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.ini
@@ -41,6 +41,7 @@ org.deepin.dde.keybinding.shortcut.turnoffscreen,\
 org.deepin.dde.keybinding.shortcut.video,\
 org.deepin.dde.keybinding.shortcut.volumedown,\
 org.deepin.dde.keybinding.shortcut.volumeup,\
+org.deepin.dde.keybinding.shortcut.webcam,\
 org.deepin.dde.keybinding.shortcut.wlan,\
 org.deepin.dde.keybinding.shortcut.www,\
 org.deepin.dde.keybinding.gesture.swipe3down,\

--- a/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.webcam/org.deepin.shortcut.json
+++ b/src/plugin-qt/shortcut/configs/org.deepin.dde.keybinding.shortcut.webcam/org.deepin.shortcut.json
@@ -3,7 +3,7 @@
     "version": "1.0",
     "contents": {
         "appId": {
-            "value": "org.deepin.dde.shortcut.dde-app",
+            "value": "org.deepin.dde.keybinding",
             "serial": 0,
             "flags": [],
             "name": "appId",
@@ -13,35 +13,25 @@
             "visibility": "private"
         },
         "displayName": {
-            "value": "Grand search",
-            "serial": 1,
+            "value": "Camera",
+            "serial": 0,
             "flags": [],
             "name": "displayName",
-            "name[zh_CN]": "全局搜索",
-            "description": "全局搜索快捷键",
-            "permissions": "",
-            "visibility": "private"
-        },
-        "displayOrder": {
-            "value": 30,
-            "serial": 1,
-            "flags": [],
-            "name": "displayOrder",
-            "name[zh_CN]": "显示顺序",
-            "description": "Display order within the category",
+            "name[zh_CN]": "相机",
+            "description": "打开或关闭相机快捷键",
             "permissions": "",
             "visibility": "private"
         },
         "hotkeys": {
             "value": [
-                "Shift+Space"
+                "WebCam"
             ],
             "serial": 0,
             "flags": [],
             "name": "hotkeys",
             "name[zh_CN]": "快捷键组合",
             "description": "快捷键组合",
-            "permissions": "readwrite",
+            "permissions": "",
             "visibility": "private"
         },
         "triggerType": {
@@ -56,7 +46,7 @@
         },
         "triggerValue": {
             "value": [
-                "/usr/libexec/dde-services/keybinding/toggle-grand-search"
+                "/usr/libexec/dde-services/keybinding/camera-switch"
             ],
             "serial": 0,
             "flags": [],
@@ -83,16 +73,16 @@
             "name": "enabled",
             "name[zh_CN]": "使能",
             "description": "是否启用快捷键",
-            "permissions": "readwrite",
+            "permissions": "",
             "visibility": "private"
         },
         "modifiable": {
-            "value": true,
+            "value": false,
             "serial": 0,
             "flags": [],
             "name": "modifiable",
             "name[zh_CN]": "能否修改快捷键",
-            "description": "能否修改快捷键",
+            "description": "不能修改快捷键",
             "permissions": "",
             "visibility": "private"
         }

--- a/src/plugin-qt/shortcut/scripts/camera-switch
+++ b/src/plugin-qt/shortcut/scripts/camera-switch
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+user_id=$(id -u) || exit 1
+
+if /usr/bin/pgrep -u "$user_id" -x deepin-camera >/dev/null 2>&1; then
+    exec /usr/bin/pkill -u "$user_id" -x deepin-camera
+fi
+
+exec /usr/bin/dde-am deepin-camera

--- a/src/plugin-qt/shortcut/scripts/toggle-grand-search
+++ b/src/plugin-qt/shortcut/scripts/toggle-grand-search
@@ -1,0 +1,34 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+service=com.deepin.dde.GrandSearch
+object_path=/com/deepin/dde/GrandSearch
+interface=com.deepin.dde.GrandSearch
+
+registered=$(/usr/bin/dbus-send --session --print-reply \
+    --dest=org.freedesktop.DBus \
+    /org/freedesktop/DBus \
+    org.freedesktop.DBus.NameHasOwner \
+    string:"$service")
+
+if printf '%s\n' "$registered" | /usr/bin/grep -q true; then
+    visible=$(/usr/bin/dbus-send --session --print-reply=literal \
+        --dest="$service" \
+        "$object_path" \
+        "$interface.IsVisible")
+
+    if printf '%s\n' "$visible" | /usr/bin/grep -q true; then
+        target=false
+    else
+        target=true
+    fi
+else
+    target=true
+fi
+
+exec /usr/bin/dbus-send --session --print-reply=literal \
+    --dest="$service" \
+    "$object_path" \
+    "$interface.SetVisible" \
+    boolean:"$target"

--- a/src/plugin-qt/shortcut/src/core/serviceactionexecutor.cpp
+++ b/src/plugin-qt/shortcut/src/core/serviceactionexecutor.cpp
@@ -34,8 +34,7 @@ bool ServiceActionExecutor::execute(TriggerActionId actionId, const QString &con
     case TriggerActionId::ToggleGrandSearch:
         success = m_actionExecutor
                 && m_actionExecutor->executeCommand({
-                        QStringLiteral(
-                                "/usr/libexec/dde-daemon/keybinding/shortcut-dde-grand-search.sh"),
+                        QStringLiteral("/usr/libexec/dde-services/keybinding/toggle-grand-search"),
                 });
         break;
     case TriggerActionId::ToggleLauncher:

--- a/src/plugin-qt/shortcut/tests/tst_qkeysequenceconverter.cpp
+++ b/src/plugin-qt/shortcut/tests/tst_qkeysequenceconverter.cpp
@@ -28,6 +28,8 @@ void TestQKeySequenceConverter::symbolKeysUseXkbNames_data()
                             << QStringLiteral("<Super>equal");
     QTest::newRow("display") << QStringLiteral("Display")
                               << QStringLiteral("XF86Display");
+    QTest::newRow("webcam") << QStringLiteral("WebCam")
+                             << QStringLiteral("XF86WebCam");
 }
 
 void TestQKeySequenceConverter::symbolKeysUseXkbNames()


### PR DESCRIPTION
## Summary
- add the missing XF86WebCam shortcut and preserve the legacy camera toggle behavior
- install camera and grand-search helper scripts under a dde-services-owned path
- keep the default-terminal shortcut on dde-daemon's independently installed binary

## Test plan
- `sh -n` on both helper scripts
- validate the webcam DConfig JSON with `jq`
- run `shortcut-qkeysequenceconverter`
- verify both installed helper scripts have mode `0755`

## Summary by Sourcery

Migrate camera and grand search shortcut handling to dde-services while adding support for the XF86WebCam key.

New Features:
- Introduce a webcam shortcut configuration wired to the XF86WebCam key and corresponding camera-switch helper script.

Enhancements:
- Relocate grand search shortcut execution to a new toggle-grand-search helper under the dde-services keybinding libexec path.
- Install camera and grand search helper scripts under a dde-services-owned libexec keybinding directory to align with service ownership.

Tests:
- Extend shortcut key sequence converter tests to cover the WebCam/XF86WebCam mapping.