### PR TITLE
fix(xsettings): apply X11 scaling live

### DIFF
--- a/src/plugin-qt/xsettings/CMakeLists.txt
+++ b/src/plugin-qt/xsettings/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 set(BIN_NAME "plugin-dde-xsettings")
@@ -11,6 +11,7 @@ set(CMAKE_AUTORCC ON)
 
 include(GNUInstallDirs)
 file(GLOB_RECURSE SRCS "*.h" "*.cpp")
+list(FILTER SRCS EXCLUDE REGEX "/tests/")
 
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus)
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Gui Core)
@@ -45,3 +46,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/org.deepin.dde.XSettings1.service
     RENAME org.deepin.dde.XSettings1.service
 )
 install_user_symlink(org.deepin.dde.XSettings1.service dde-session-pre.target.wants)
+
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/src/plugin-qt/xsettings/impl/xsettingsmanager.cpp
+++ b/src/plugin-qt/xsettings/impl/xsettingsmanager.cpp
@@ -203,6 +203,8 @@ void XSettingsManager::setScreenScaleFactors(const ScaleFactors &factors, bool e
     }
 
     setScreenScaleFactorsForQt(factors);
+
+    updateDPI();
 }
 
 void XSettingsManager::setString(const QString &prop, const QString &v)
@@ -391,15 +393,11 @@ void XSettingsManager::updateDPI()
         int tempXftDpi = m_settingDconfig->value(dcKeyXftDpi).toInt(&bOk);
         if (bOk) {
             scaledDpi = static_cast<int>((DPI_FALLBACK * 1024) * scale);
-            if (tempXftDpi != scaledDpi) {
+            const auto update = makeXftDpiUpdate(tempXftDpi, scaledDpi);
+            if (update.needsPersist) {
                 m_settingDconfig->setValue(dcKeyXftDpi, scaledDpi);
-                XsSetting setting;
-                setting.prop = "Xft/DPI";
-                setting.value = scaledDpi;
-                setting.type = HeadTypeInteger;
-
-                xsSettngVec.push_back(setting);
             }
+            xsSettngVec.push_back(update.setting);
         }
 
         bOk = false;

--- a/src/plugin-qt/xsettings/modules/common/common.h
+++ b/src/plugin-qt/xsettings/modules/common/common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #ifndef COMMON_H
@@ -51,5 +51,19 @@ const int8_t HeadTypeInvalid = -1;
 const int8_t HeadTypeInteger = 0;
 const int8_t HeadTypeString = 1;
 const int8_t HeadTypeColor = 2;
+
+struct XftDpiUpdate
+{
+    bool needsPersist;
+    XsSetting setting;
+};
+
+inline XftDpiUpdate makeXftDpiUpdate(int storedDpi, int scaledDpi)
+{
+    return {
+        storedDpi != scaledDpi,
+        { HeadTypeInteger, QStringLiteral("Xft/DPI"), scaledDpi },
+    };
+}
 
 #endif // COMMON_H

--- a/src/plugin-qt/xsettings/tests/CMakeLists.txt
+++ b/src/plugin-qt/xsettings/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+add_executable(tst-xftdpiupdate
+    tst_xftdpiupdate.cpp
+)
+
+target_include_directories(tst-xftdpiupdate PRIVATE
+    ..
+)
+
+target_link_libraries(tst-xftdpiupdate PRIVATE
+    Qt6::Core
+    Qt6::Test
+)
+
+add_test(NAME xsettings-xftdpiupdate COMMAND tst-xftdpiupdate)

--- a/src/plugin-qt/xsettings/tests/tst_xftdpiupdate.cpp
+++ b/src/plugin-qt/xsettings/tests/tst_xftdpiupdate.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <QtTest>
+
+#include "modules/common/common.h"
+
+class XftDpiUpdateTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void persistsChangedValue();
+    void republishesUnchangedValue();
+};
+
+void XftDpiUpdateTest::persistsChangedValue()
+{
+    const auto update = makeXftDpiUpdate(96 * 1024, 192 * 1024);
+
+    QVERIFY(update.needsPersist);
+    QCOMPARE(update.setting.prop, QStringLiteral("Xft/DPI"));
+    QCOMPARE(update.setting.type, HeadTypeInteger);
+    QCOMPARE(std::get<int>(update.setting.value), 192 * 1024);
+}
+
+void XftDpiUpdateTest::republishesUnchangedValue()
+{
+    const auto update = makeXftDpiUpdate(192 * 1024, 192 * 1024);
+
+    QVERIFY(!update.needsPersist);
+    QCOMPARE(update.setting.prop, QStringLiteral("Xft/DPI"));
+    QCOMPARE(std::get<int>(update.setting.value), 192 * 1024);
+}
+
+QTEST_APPLESS_MAIN(XftDpiUpdateTest)
+
+#include "tst_xftdpiupdate.moc"


### PR DESCRIPTION
## Summary

- refresh XSettings DPI values immediately after screen scale factors change
- republish `Xft/DPI` even when its persisted value is unchanged
- add focused tests for DPI persistence and publication

## Verification

- built `plugin-dde-xsettings` and `tst-xftdpiupdate`
- `tst-xftdpiupdate`: 4 passed, 0 failed
- X11 smoke test observed `DevicePixelRatioChange` from 2 to 1.98958

## Summary by Sourcery

Ensure X11 Xft/DPI settings are updated and republished in response to screen scaling changes, and add targeted tests and build wiring for the new DPI update logic.

Bug Fixes:
- Refresh XSettings DPI values when screen scale factors change and always publish the Xft/DPI setting to X11 even if its persisted value is unchanged.

Enhancements:
- Introduce an XftDpiUpdate helper to encapsulate DPI persistence and publication logic.

Build:
- Exclude test sources from the plugin build and wire in an optional tests subdirectory for the xsettings module.

Tests:
- Add a Qt-based unit test binary and test cases to verify Xft/DPI persistence and republishing behavior.