### PR TITLE
fix: change default ambient brightness to off

### DIFF
--- a/src/plugin-qt/ambient-brightness/configs/org.deepin.dde.daemon.ambient-brightness.json
+++ b/src/plugin-qt/ambient-brightness/configs/org.deepin.dde.daemon.ambient-brightness.json
@@ -3,7 +3,7 @@
     "version": "1.0",
     "contents": {
         "ambientLightAdjustBrightness": {
-            "value": true,
+            "value": false,
             "serial": 0,
             "flags": [],
             "name": "Ambient light auto brightness",


### PR DESCRIPTION
According to product design, the ambient light auto brightness feature should be disabled by default. This commit updates the default value of `ambientLightAdjustBrightness` from `true` to `false` in the configuration file.

Log: Ambient brightness default changed to off

Influence:
1. Verify that the ambient brightness switch is initially off on fresh install
2. Test manually enabling the feature and confirm it works as expected
3. Check that upgrading from a previous version does not override user's custom setting (if applicable)

fix: 将自动亮度默认值改为关闭

根据产品设计，自动亮度功能默认应关闭。本次提交将配置项
`ambientLightAdjustBrightness` 的默认值从 `true` 改为 `false`。

Log: 自动亮度默认关闭

Influence:
1. 验证新安装系统下自动亮度开关默认关闭
2. 测试手动开启后功能是否正常
3. 检查从旧版本升级后，用户自定义设置是否被保留（如适用）

PMS: BUG-372191

## Summary by Sourcery

Bug Fixes:
- Disable ambient brightness adjustment by default for fresh installations.