### PR TITLE
fix: change default ambient brightness to off

### DIFF
--- a/src/plugin-qt/ambient-brightness/configs/org.deepin.dde.daemon.ambient-brightness.json
+++ b/src/plugin-qt/ambient-brightness/configs/org.deepin.dde.daemon.ambient-brightness.json
@@ -3,7 +3,7 @@
     "version": "1.0",
     "contents": {
         "ambientLightAdjustBrightness": {
-            "value": true,
+            "value": false,
             "serial": 0,
             "flags": [],
             "name": "Ambient light auto brightness",


### PR DESCRIPTION
## Backport to `release/2500`

本次为提交 `ffefe3d8`（即 PR #152，"fix: change default ambient brightness to off"）的 cherry-pick backport 到 `release/2500` 分支。

## 改动内容

将 DConfig 配置项 `ambientLightAdjustBrightness` 的默认值从 `true` 改为 `false`，即默认关闭环境光自动亮度功能（关联 PMS: BUG-372191）。

仅 1 个文件、1 行变更：

- `src/plugin-qt/ambient-brightness/configs/org.deepin.dde.daemon.ambient-brightness.json`
  - `"value": true` → `"value": false`

DConfig meta 结构（`magic`/`version`/`contents`/`serial`/`flags`）保持完好，JSON 校验通过；运行时代码通过 DConfig 动态读取该键，默认值变更即可生效，无需改 cpp。

## 关联

- 上游 PR：#152（已合并入 `master`）
- PMS：BUG-372191
- Multica issue：DDE-125 — https://agent-dev.uniontech.com/dde/issues/6b9f9df7-08d6-4f75-95f7-4beb8d46f45f

## 说明

- cherry-pick 保留原提交作者（`fuleyi <fuleyi@uniontech.com>`）与完整 commit message（含 `PMS: BUG-372191`），cherry-pick 无冲突。
- 已通过代码审核（100 分 / 优秀 / Low 风险，0 条意见）。
- 本 PR 为 draft / 待审核状态，合并由人工确认，请勿自动合并。

> 注：本 Multica issue（DDE-125）的 done 状态由用户人工确认，PR 合并不应自动关闭该 issue。

## Summary by Sourcery

Bug Fixes:
- Disable ambient-light automatic brightness by default by changing the DConfig default for `ambientLightAdjustBrightness` from enabled to disabled.