### PR TITLE
fix(power): secure system power actions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends:  debhelper (>= 11),
  libnet-dev,
  libglib2.0-dev,
  libdtk6gui-dev,
+ libpolkit-qt6-1-dev,
  libdtk6core-dev,
  libx11-dev,
  libxext-dev,
@@ -44,7 +45,8 @@ Depends:
  ${misc:Depends},
  deepin-service-manager (>> 1.0.21),
  dbus,
- deepin-power-control (>= 2.0.1)
+ deepin-power-control (>= 2.0.1),
+ deepin-security-loader
 Recommends:
  iio-sensor-proxy
 Breaks: dde-daemon (<< 6.1.102)

--- a/src/plugin-qt/power/system/CMakeLists.txt
+++ b/src/plugin-qt/power/system/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus)
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(UDEV REQUIRED libudev)
+pkg_check_modules(POLKIT_QT REQUIRED polkit-qt6-1)
 
 file(GLOB_RECURSE SRCS "*.cpp" "*.h")
 
@@ -24,6 +25,7 @@ add_library(${BIN_NAME} MODULE ${SRCS})
 target_include_directories(${BIN_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${UDEV_INCLUDE_DIRS}
+    ${POLKIT_QT_INCLUDE_DIRS}
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
@@ -31,6 +33,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::DBus
     Dtk${DTK_VERSION_MAJOR}::Core
     ${UDEV_LIBRARIES}
+    ${POLKIT_QT_LIBRARIES}
 )
 
 install(TARGETS ${BIN_NAME}

--- a/src/plugin-qt/power/system/misc/dbus/org.deepin.dde.Power1.conf
+++ b/src/plugin-qt/power/system/misc/dbus/org.deepin.dde.Power1.conf
@@ -8,6 +8,16 @@
   <!-- Only root can own the service -->
   <policy user="root">
     <allow own="org.deepin.dde.Power1"/>
+    <allow send_destination="org.deepin.dde.Power1"
+           send_interface="org.deepin.dde.Power1"
+           send_member="SetAllowCaller"/>
+  </policy>
+
+  <!-- Only root and deepin-daemon group can call SetAllowCaller. -->
+  <policy group="deepin-daemon">
+    <allow send_destination="org.deepin.dde.Power1"
+           send_interface="org.deepin.dde.Power1"
+           send_member="SetAllowCaller"/>
   </policy>
 
   <!-- Preserve the legacy user-facing Power1 mode and battery API used by DCC.
@@ -33,6 +43,10 @@
 
     <allow send_destination="org.deepin.dde.Power1.Battery"
            send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <deny send_destination="org.deepin.dde.Power1"
+          send_interface="org.deepin.dde.Power1"
+          send_member="SetAllowCaller"/>
 
   </policy>
 

--- a/src/plugin-qt/power/system/powermanager.cpp
+++ b/src/plugin-qt/power/system/powermanager.cpp
@@ -9,6 +9,7 @@
 #include "../powerconstants.h"
 
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QVariantMap>
@@ -16,19 +17,29 @@
 #include <QProcess>
 #include <QTimer>
 #include <QFile>
+#include <QDir>
 #include <QFileInfo>
 #include <QJsonDocument>
+#include <QSaveFile>
 #include <QJsonObject>
 #include <QJsonParseError>
 #include <DConfig>
 #include <QLoggingCategory>
+#include <polkitqt1-authority.h>
+#include <polkitqt1-subject.h>
+
+#include <grp.h>
 
 using namespace PowerDBus;
 using namespace PowerFS;
 using namespace PowerDConfig;
 
+static constexpr auto kPowerScope = "org.deepin.dde.Power1:/org/deepin/dde/Power1";
+static constexpr auto kAllowCallerStatePath = "/run/dde-services/power_allow_callers.json";
+static constexpr auto kLegacyAllowCallerStatePath = "/run/dde-daemon/security_loader_allow_callers.json";
 Q_LOGGING_CATEGORY(logPowerSystem, "dde.power.system")
 static constexpr auto kLegacyDBusError = "org.deepin.dde.DBus.Error.Unnamed";
+static constexpr auto kPowerAction = "org.deepin.dde.power.doAction";
 
 static bool readProcLidClosed(bool &closed)
 {
@@ -53,6 +64,253 @@ static bool isValidPowerMode(const QString &mode)
         || mode == QLatin1String("powersave")
         || mode == QLatin1String("performance")
         || mode == QLatin1String("lowBattery");
+}
+
+static bool deepinDaemonGroup(gid_t &gid)
+{
+    const group *entry = getgrnam("deepin-daemon");
+    if (!entry)
+        return false;
+    gid = entry->gr_gid;
+    return true;
+}
+
+static bool processHasGroup(uint pid, gid_t gid)
+{
+    QFile file(QStringLiteral("/proc/%1/status").arg(pid));
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+
+    while (!file.atEnd()) {
+        const QString line = QString::fromLatin1(file.readLine());
+        if (!line.startsWith(QLatin1String("Gid:")) && !line.startsWith(QLatin1String("Groups:")))
+            continue;
+        const QStringList values = line.section(QLatin1Char(':'), 1).split(QChar::Space, Qt::SkipEmptyParts);
+        for (const QString &value : values) {
+            if (value.toUInt() == gid)
+                return true;
+        }
+    }
+    return false;
+}
+
+static bool readParentPid(uint pid, uint &parent)
+{
+    QFile file(QStringLiteral("/proc/%1/status").arg(pid));
+    if (!file.open(QIODevice::ReadOnly))
+        return false;
+
+    while (!file.atEnd()) {
+        const QString line = QString::fromLatin1(file.readLine());
+        if (!line.startsWith(QLatin1String("PPid:")))
+            continue;
+        bool ok = false;
+        parent = line.section(QLatin1Char(':'), 1).trimmed().toUInt(&ok);
+        return ok;
+    }
+    return false;
+}
+
+static bool isProcessDescendant(uint pid, uint ancestor)
+{
+    if (pid == 0 || ancestor == 0 || pid == ancestor)
+        return false;
+
+    for (int depth = 0; depth < 4096 && pid != 0; ++depth) {
+        uint parent = 0;
+        if (!readParentPid(pid, parent))
+            return false;
+        if (parent == ancestor)
+            return true;
+        pid = parent;
+    }
+    return false;
+}
+
+static QString systemBusId(QDBusConnection *conn)
+{
+    if (!conn)
+        return {};
+    QDBusInterface bus(QStringLiteral("org.freedesktop.DBus"),
+                       QStringLiteral("/org/freedesktop/DBus"),
+                       QStringLiteral("org.freedesktop.DBus"),
+                       *conn);
+    const QDBusReply<QString> reply = bus.call(QStringLiteral("GetId"));
+    return reply.isValid() ? reply.value() : QString();
+}
+
+bool SystemPowerManager::addAllowedCaller(const QString &uniqueName)
+{
+    if (uniqueName.isEmpty() || !uniqueName.startsWith(QLatin1Char(':')))
+        return false;
+
+    auto *bus = m_conn ? m_conn->interface() : nullptr;
+    if (!bus)
+        return false;
+
+    const QDBusReply<uint> uid = bus->serviceUid(uniqueName);
+    const QDBusReply<uint> pid = bus->servicePid(uniqueName);
+    if (!uid.isValid() || !pid.isValid())
+        return false;
+
+    if (calledFromDBus()) {
+        const QString registrar = message().service();
+        const QDBusReply<uint> registrarUid = bus->serviceUid(registrar);
+        const QDBusReply<uint> registrarPid = bus->servicePid(registrar);
+        if (!registrarUid.isValid() || !registrarPid.isValid())
+            return false;
+        if (registrarUid.value() == 0) {
+            if (uid.value() != 0)
+                return false;
+        } else {
+            gid_t daemonGroup = 0;
+            if (!deepinDaemonGroup(daemonGroup) || !processHasGroup(registrarPid.value(), daemonGroup))
+                return false;
+            if (registrarUid.value() != uid.value() || !isProcessDescendant(pid.value(), registrarPid.value()))
+                return false;
+        }
+    }
+
+    m_allowedCallers.insert(uniqueName, {uid.value(), pid.value()});
+    saveAllowedCallers();
+    return true;
+}
+
+void SystemPowerManager::loadAllowedCallers()
+{
+    QFile file{QLatin1String(kAllowCallerStatePath)};
+    const bool migrateLegacyState = !file.open(QIODevice::ReadOnly);
+    if (migrateLegacyState) {
+        file.setFileName(QLatin1String(kLegacyAllowCallerStatePath));
+        if (!file.open(QIODevice::ReadOnly))
+            return;
+    }
+
+    QJsonParseError error;
+    const QJsonDocument document = QJsonDocument::fromJson(file.readAll(), &error);
+    if (error.error != QJsonParseError::NoError || !document.isObject())
+        return;
+
+    const QJsonObject root = document.object();
+    const QString busId = systemBusId(m_conn);
+    if (busId.isEmpty() || root.value(QLatin1String("busId")).toString() != busId)
+        return;
+
+    auto *bus = m_conn ? m_conn->interface() : nullptr;
+    if (!bus)
+        return;
+
+    const QJsonObject callers = root.value(QLatin1String("callers")).toObject()
+        .value(QLatin1String(kPowerScope)).toObject();
+    for (auto it = callers.begin(); it != callers.end(); ++it) {
+        const QString uniqueName = it.key();
+        const QJsonObject info = it.value().toObject();
+        const QDBusReply<uint> uid = bus->serviceUid(uniqueName);
+        const QDBusReply<uint> pid = bus->servicePid(uniqueName);
+        if (!uid.isValid() || !pid.isValid())
+            continue;
+        if (uid.value() != static_cast<uint>(info.value(QLatin1String("uid")).toInteger())
+            || pid.value() != static_cast<uint>(info.value(QLatin1String("pid")).toInteger())) {
+            continue;
+        }
+        m_allowedCallers.insert(uniqueName, {uid.value(), pid.value()});
+    }
+    if (migrateLegacyState && !m_allowedCallers.isEmpty())
+        saveAllowedCallers();
+}
+
+void SystemPowerManager::saveAllowedCallers()
+{
+    const QString busId = systemBusId(m_conn);
+    if (busId.isEmpty()) {
+        qWarning(logPowerSystem) << "Failed to get system bus ID";
+        return;
+    }
+
+    QJsonObject powerCallers;
+    for (auto it = m_allowedCallers.cbegin(); it != m_allowedCallers.cend(); ++it) {
+        powerCallers.insert(it.key(), QJsonObject{
+            {QLatin1String("uid"), static_cast<qint64>(it->uid)},
+            {QLatin1String("pid"), static_cast<qint64>(it->pid)},
+        });
+    }
+    const QJsonObject root{
+        {QLatin1String("busId"), busId},
+        {QLatin1String("callers"), QJsonObject{
+            {QLatin1String(kPowerScope), powerCallers},
+        }},
+    };
+
+    const QString stateDir = QFileInfo(QLatin1String(kAllowCallerStatePath)).absolutePath();
+    if (!QDir().mkpath(stateDir)
+        || !QFile::setPermissions(stateDir, QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner)) {
+        qWarning(logPowerSystem) << "Failed to create security-loader state directory";
+        return;
+    }
+    QSaveFile file{QLatin1String(kAllowCallerStatePath)};
+    if (!file.open(QIODevice::WriteOnly)) {
+        qWarning(logPowerSystem) << "Failed to open security-loader state file";
+        return;
+    }
+    file.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    file.write(QJsonDocument(root).toJson(QJsonDocument::Compact));
+    if (!file.commit())
+        qWarning(logPowerSystem) << "Failed to save security-loader callers";
+}
+
+bool SystemPowerManager::isAllowedCaller(const QString &uniqueName, bool &lookupFailed) const
+{
+    lookupFailed = false;
+    const auto it = m_allowedCallers.constFind(uniqueName);
+    if (it == m_allowedCallers.cend())
+        return false;
+
+    auto *bus = m_conn ? m_conn->interface() : nullptr;
+    if (!bus) {
+        lookupFailed = true;
+        return false;
+    }
+
+    const QDBusReply<uint> uid = bus->serviceUid(uniqueName);
+    const QDBusReply<uint> pid = bus->servicePid(uniqueName);
+    if (!uid.isValid() || !pid.isValid()) {
+        lookupFailed = true;
+        return false;
+    }
+    return uid.value() == it->uid && pid.value() == it->pid;
+}
+
+bool SystemPowerManager::authorizePowerAction()
+{
+    if (!calledFromDBus())
+        return true;
+
+    const QString sender = message().service();
+    bool lookupFailed = false;
+    if (isAllowedCaller(sender, lookupFailed))
+        return true;
+    if (lookupFailed) {
+        sendErrorReply(QDBusError::AccessDenied, QStringLiteral("Failed to verify caller credentials"));
+        return false;
+    }
+    auto *authority = PolkitQt1::Authority::instance();
+    authority->clearError();
+    const auto result = authority->checkAuthorizationSync(
+        QLatin1String(kPowerAction),
+        PolkitQt1::SystemBusNameSubject(sender),
+        PolkitQt1::Authority::AllowUserInteraction);
+    if (authority->hasError()) {
+        const QString error = authority->errorDetails();
+        authority->clearError();
+        qWarning(logPowerSystem) << "Polkit authorization failed:" << error;
+        sendErrorReply(QDBusError::AccessDenied, error.isEmpty() ? QStringLiteral("Authentication failed") : error);
+        return false;
+    }
+    if (result != PolkitQt1::Authority::Yes) {
+        sendErrorReply(QDBusError::AccessDenied, QStringLiteral("Authentication failed"));
+        return false;
+    }
+    return true;
 }
 
 SystemPowerManager::SystemPowerManager(QDBusConnection *conn, const QString &svc,
@@ -85,6 +343,7 @@ bool SystemPowerManager::initialize()
         qWarning(logPowerSystem) << "registerObject failed";
         return false;
     }
+    loadAllowedCallers();
 
     m_powerControlProcess = new QProcess(this);
     connect(m_powerControlProcess,
@@ -700,11 +959,17 @@ void SystemPowerManager::setSupportSwitchPowerMode(bool value)
 
 void SystemPowerManager::SetCpuGovernor(const QString &gov)
 {
+    if (!authorizePowerAction())
+        return;
+
     setCpuGovernor(gov);
 }
 
 void SystemPowerManager::SetCpuBoost(bool on)
 {
+    if (!authorizePowerAction())
+        return;
+
     setCpuBoost(on);
 }
 
@@ -716,6 +981,9 @@ void SystemPowerManager::LockCpuFreq(const QString &gov, int lockTime)
 
 void SystemPowerManager::SetMode(const QString &mode)
 {
+    if (!authorizePowerAction())
+        return;
+
     if (m_mode == mode) {
         const QString error = QStringLiteral("repeat set mode");
         if (calledFromDBus())
@@ -742,8 +1010,22 @@ void SystemPowerManager::SetMode(const QString &mode)
     setMode(mode);
 }
 
+void SystemPowerManager::SetAllowCaller(const QString &uniqueName)
+{
+    if (!addAllowedCaller(uniqueName)) {
+        const QString error = QStringLiteral("invalid caller %1").arg(uniqueName);
+        if (calledFromDBus())
+            sendErrorReply(QDBusError::InvalidArgs, error);
+        else
+            qWarning(logPowerSystem) << error;
+    }
+}
+
 void SystemPowerManager::SetTlpMode(const QString &mode)
 {
+    if (!authorizePowerAction())
+        return;
+
     QString error;
     if (m_tlpMode == mode)
         error = QStringLiteral("repeat set tlp mode");

--- a/src/plugin-qt/power/system/powermanager.h
+++ b/src/plugin-qt/power/system/powermanager.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QDBusConnection>
 #include <QDBusContext>
+#include <QHash>
 #include <QDBusObjectPath>
 #include <QString>
 #include <QSet>
@@ -112,6 +113,7 @@ public Q_SLOTS:
     void LockCpuFreq(const QString &gov, int lockTime);
     void SetMode(const QString &mode);
     void SetTlpMode(const QString &mode);
+    void SetAllowCaller(const QString &uniqueName);
     void SetShortIdleState(bool state);
 
 Q_SIGNALS:
@@ -158,6 +160,17 @@ private:
     void enqueuePowerControl(const QStringList &arguments);
     void runNextPowerControl();
 
+    bool addAllowedCaller(const QString &uniqueName);
+    bool isAllowedCaller(const QString &uniqueName, bool &lookupFailed) const;
+    void loadAllowedCallers();
+    void saveAllowedCallers();
+    bool authorizePowerAction();
+
+    struct AllowedCaller {
+        uint uid = 0;
+        uint pid = 0;
+    };
+
     QDBusConnection *m_conn;
 
     bool m_onBattery = false;
@@ -201,4 +214,5 @@ private:
     QProcess *m_powerControlProcess = nullptr;
     QQueue<QStringList> m_powerControlQueue;
     bool m_powerControlBusy = false;
+    QHash<QString, AllowedCaller> m_allowedCallers;
 };


### PR DESCRIPTION
This is a stacked security follow-up for #153 and contains only the system Power1 authorization integration.

1. Register trusted callers with persisted UID and PID validation.
2. Authorize privileged power changes through caller records or Polkit.
3. Restrict SetAllowCaller to trusted registrars and D-Bus policies.
4. Add the deepin-security-loader and Polkit build/runtime dependencies.

This PR is intentionally separate because the security-loader authorization design may change independently. After #153 merges, retarget this PR to master.

Log: Protect system Power1 mutations with explicit caller authorization.
PMS: TASK-394241
Influence: System power changes require authorization.

## Summary by Sourcery

Secure Power1 system power actions with trusted caller validation and Polkit authorization.

New Features:
- Add trusted caller registration with persisted UID and PID validation for Power1 operations.
- Authorize privileged system power changes through trusted callers or Polkit.

Enhancements:
- Restrict SetAllowCaller to authorized root or deepin-daemon callers through D-Bus policy enforcement.
- Protect system power mutation methods with explicit caller authorization checks.

Build:
- Add the polkit-qt6 dependency to the system power module build.